### PR TITLE
Fixed: If products are empty, python complains about rstrip()ing NoneType.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,4 +39,5 @@ $ cd hyperion && git log
 - Added the `asset_hosts_filter` parameter to `createTarget` mutation [#15](https://github.com/greenbone/hyperion/pull/15)
 - Added the `allow_simultaneous_ips` parameter to `createTarget`, `modifyTarget` mutation and `getTarget(s)` queries. [#15](https://github.com/greenbone/hyperion/pull/15)
 - Fixed `FutureWarnings` due to `if x:` -> `if x is not None:` [#27](https://github.com/greenbone/hyperion/pull/27)
-- Added missing fields to `CVE` entity [#39](https://github.com/greenbone/hyperion/pull/39)
+- Added missing fields to `CPE` entity [#39](https://github.com/greenbone/hyperion/pull/39)
+- Fix product rstrip() from NoneType error. [#41](https://github.com/greenbone/hyperion/pull/41)

--- a/selene/schema/cves/fields.py
+++ b/selene/schema/cves/fields.py
@@ -199,7 +199,9 @@ class CVE(EntityObjectType):
     def resolve_products(root, _info):
         cve = root.find('cve')
         if cve is not None:
-            return get_text_from_element(cve, 'products').rstrip().split(' ')
+            products = get_text_from_element(cve, 'products')
+            if products is not None:
+                return products.rstrip().split(' ')
         return None
 
     def resolve_nvt_refs(root, _info):


### PR DESCRIPTION
* CVE products will not raise an error, if they are empty anymore.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

* Frontend complains about "'NoneType' object has no attribute 'rstrip'"

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
