### PR TITLE
Fix: Prevent call len() on NoneType in permissions

### DIFF
--- a/selene/schema/entity.py
+++ b/selene/schema/entity.py
@@ -97,7 +97,7 @@ class EntityObjectType(graphene.ObjectType):
 
     def resolve_permissions(root, _info):
         permissions = root.find('permissions')
-        if len(permissions) == 0:
+        if permissions is None or len(permissions) == 0:
             return None
         return permissions.findall('permission')
 

--- a/selene/tests/permissions/test_get_permission.py
+++ b/selene/tests/permissions/test_get_permission.py
@@ -181,6 +181,42 @@ class GetPermissionTestCase(SeleneTestCase):
             "6fe1f935-d8eb-4b78-a1d7-1fce90af227c"
         )
 
+    def test_get_permission_is_none(self, mock_gmp: GmpMockFactory):
+        mock_gmp.mock_response(
+            'get_permission',
+            '''
+            <get_permissions_response status="200" status_text="OK">
+            <permission id="ecade4f9-cc42-4f51-b5db-7cbcf90fc8b6">
+            </permission>
+            </get_permissions_response>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            '''
+            query {
+                permission(
+                    id: "6fe1f935-d8eb-4b78-a1d7-1fce90af227c",
+                ) {
+                    permissions {
+                        name
+                    }
+                }
+            }
+            '''
+        )
+
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        permissions = json['data']['permission']['permissions']
+
+        # Entity fields
+        self.assertIsNone(permissions)
+
 
 class PermissionGetEntityTestCase(SeleneTestCase):
     gmp_name = 'permission'


### PR DESCRIPTION
Fix: Prevent call len() on NoneType in permissions, if they are empty… (e.g. in NVTs)

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* To have a not failing Query. :)

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
