### PR TITLE
Support credential download and add fields to Credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ $ cd hyperion && git log
 
 ## [Unreleased]
 ### Added
+- Support credential download and add fields to Credential [#66](https://github.com/greenbone/hyperion/pull/66)
 - Add `compliance_count` to AuditLastReport [#26](https://github.com/greenbone/hyperion/pull/26)
 - Implement `average_duration` for tasks and audits fields. [#14](https://github.com/greenbone/hyperion/pull/14)
 - Implement new abstract Class for SecInfo BulkExport by IDs. [#24](https://github.com/greenbone/hyperion/pull/24)

--- a/selene/schema/credentials/fields.py
+++ b/selene/schema/credentials/fields.py
@@ -68,6 +68,9 @@ class Credential(EntityObjectType):
     privacy_algorithm = graphene.Field(PrivacyAlgorithm)
     scanners = graphene.List(Scanner)
     targets = graphene.List(Target)
+    credential_package = graphene.String()
+    certificate = graphene.String()
+    public_key = graphene.String()
 
     def resolve_login(root, _info):
         return get_text_from_element(root, 'login')
@@ -96,3 +99,12 @@ class Credential(EntityObjectType):
         if len(targets) == 0:
             return None
         return targets.findall('target')
+
+    def resolve_credential_package(root, _info):
+        return get_text_from_element(root, 'package')
+
+    def resolve_certificate(root, _info):
+        return get_text_from_element(root, 'certificate')
+
+    def resolve_public_key(root, _info):
+        return get_text_from_element(root, 'public_key')

--- a/selene/schema/credentials/fields.py
+++ b/selene/schema/credentials/fields.py
@@ -22,6 +22,7 @@ import graphene
 
 from gvm.protocols.next import (
     CredentialType as GvmCredentialType,
+    CredentialFormat as GvmCredentialFormat,
     SnmpAuthAlgorithm,
     SnmpPrivacyAlgorithm,
 )
@@ -49,6 +50,11 @@ class AuthAlgorithm(graphene.Enum):
 class PrivacyAlgorithm(graphene.Enum):
     class Meta:
         enum = SnmpPrivacyAlgorithm
+
+
+class CredentialFormat(graphene.Enum):
+    class Meta:
+        enum = GvmCredentialFormat
 
 
 class Credential(EntityObjectType):

--- a/selene/schema/credentials/queries.py
+++ b/selene/schema/credentials/queries.py
@@ -24,7 +24,7 @@ import graphene
 
 from graphql import ResolveInfo
 
-from selene.schema.credentials.fields import Credential
+from selene.schema.credentials.fields import Credential, CredentialFormat
 
 from selene.schema.parser import FilterString
 
@@ -79,16 +79,35 @@ class GetCredential(graphene.Field):
             credential_id=graphene.UUID(required=True, name='id'),
             scanners=graphene.Boolean(default_value=True),
             targets=graphene.Boolean(default_value=True),
+            credential_format=graphene.String(
+                default_value=None, name='format'
+            ),
             resolver=self.resolve,
         )
 
     @staticmethod
     @require_authentication
-    def resolve(_root, info, credential_id: UUID, targets, scanners):
+    def resolve(
+        _root,
+        info,
+        credential_id: UUID,
+        targets,
+        scanners,
+        credential_format=None,
+    ):
         gmp = get_gmp(info)
 
+        cred_format = (
+            CredentialFormat.get(credential_format)
+            if credential_format
+            else None
+        )
+
         xml = gmp.get_credential(
-            str(credential_id), scanners=scanners, targets=targets
+            str(credential_id),
+            scanners=scanners,
+            targets=targets,
+            credential_format=cred_format,
         )
         return xml.find('credential')
 


### PR DESCRIPTION
**What**:

Support argument `credential_format` in single Credential query and include fields in the `Credential` entity to support download of `credentialPackage`, `publicKey` and `certificate` formats.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

In GSA it is possible to download these formats and without the `credential_format` argument, this does not work.

<!-- Why are these changes necessary? -->

**How**:

Unit tests. 

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
