### PR TITLE
Splitting preferences in scanconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,5 @@ $ cd hyperion && git log
 - Added missing fields to `CPE` entity [#39](https://github.com/greenbone/hyperion/pull/39)
 - Fix product rstrip() from NoneType error. [#41](https://github.com/greenbone/hyperion/pull/41)
 - Adding missing field `port` to `override` entity. [#57](https://github.com/greenbone/hyperion/pull/57)
+- Improved `Report` Entity, fixed and tested `ReportError` [65](https://github.com/greenbone/hyperion/pull/65)
+- Split `ScannerPreferences` and `NVTPreferences` in `ScanConfigs` and `Policies` [67](https://github.com/greenbone/hyperion/pull/67)

--- a/selene/schema/policies/fields.py
+++ b/selene/schema/policies/fields.py
@@ -53,13 +53,13 @@ class PolicyFamily(graphene.ObjectType):
         return get_boolean_from_element(root, 'growing')
 
 
-class PolicyTask(graphene.ObjectType):
-    """"Task which is using the policy."""
+class PolicyAudit(graphene.ObjectType):
+    """"Audit which is using the policy."""
 
-    task_id = graphene.String(name='id')
+    audit_id = graphene.String(name='id')
     name = graphene.String()
 
-    def resolve_task_id(root, _info):
+    def resolve_audit_id(root, _info):
         return root.get('id')
 
     def resolve_name(root, _info):
@@ -112,8 +112,8 @@ class Policy(EntityObjectType):
         ScannerPreference,
         description='List of Scanner Preferences for this Policy',
     )
-    tasks = graphene.List(
-        PolicyTask, description='List of Tasks using this Policy'
+    audits = graphene.List(
+        PolicyAudit, description='List of Audits using this Policy'
     )
     nvt_selectors = graphene.List(PolicyNvtSelector)
 
@@ -180,11 +180,11 @@ class Policy(EntityObjectType):
                 ]
         return None
 
-    def resolve_tasks(root, _info):
-        tasks = root.find('tasks')
-        if tasks is None:
+    def resolve_audits(root, _info):
+        audits = root.find('tasks')
+        if audits is None:
             return None
-        return tasks.findall('task')
+        return audits.findall('task')
 
     def resolve_nvt_selectors(root, _info):
         selectors = root.find('nvt_selectors')

--- a/selene/tests/policies/example-policy.xml
+++ b/selene/tests/policies/example-policy.xml
@@ -1,0 +1,96 @@
+<get_config_response status="200" status_text="OK">
+    <config id="daba56c8-73ec-11df-a475-002264764cea">
+        <name>foo</name>
+        <type>0</type>
+        <usage_type>scan</usage_type>
+        <predefined>1</predefined>
+        <trash>0</trash>
+        <family_count>2<growing>1</growing></family_count>
+        <nvt_count>3<growing>0</growing></nvt_count>
+        <type>0</type>
+        <usage_type>scan</usage_type>
+        <families>
+        <family>
+            <name>Port scanners</name>
+            <nvt_count>2</nvt_count>
+            <max_nvt_count>9</max_nvt_count>
+            <growing>0</growing>
+        </family>
+        <family>
+            <name>Service detection</name>
+            <nvt_count>1</nvt_count>
+            <max_nvt_count>240</max_nvt_count>
+            <growing>0</growing>
+        </family>
+        </families>
+        <max_nvt_count>249</max_nvt_count>
+        <known_nvt_count>3</known_nvt_count>
+        <preferences>
+            <preference>
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                    <name>Ping Host</name>
+                </nvt>
+                <id>13</id>
+                <hr_name>Log failed nmap calls</hr_name>
+                <name>Log failed nmap calls</name>
+                <type>checkbox</type>
+                <value>no</value>
+                <default>no</default>
+            </preference>
+            <preference>
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                    <name>Ping Host</name>
+                </nvt>
+                <id>14</id>
+                <hr_name>nmap timing policy</hr_name>
+                <name>nmap timing policy</name>
+                <type>radio</type>
+                <value>Normal</value>
+                <alt>Paranoid</alt>
+                <alt>Sneaky</alt>
+                <default>Normal</default>
+            </preference>
+            <preference>
+                <nvt oid="">
+                <name/>
+                </nvt>
+                <id/>
+                <hr_name>auto_enable_dependencies</hr_name>
+                <name>auto_enable_dependencies</name>
+                <type/>
+                <value>1</value>
+                <default>1</default>
+            </preference>
+            <preference>
+                <nvt oid="">
+                <name/>
+                </nvt>
+                <id/>
+                <hr_name>cgi_path</hr_name>
+                <name>cgi_path</name>
+                <type/>
+                <value>/cgi-bin:/scripts</value>
+                <default>/cgi-bin:/scripts</default>
+            </preference>
+        </preferences>
+        <tasks>
+            <task id="49d082ec-73f5-4b3a-75b5-3b9d9e38d079">
+                <name>some_name</name>
+            </task>
+        </tasks>
+        <nvt_selectors>
+            <nvt_selector>
+                <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                <include>1</include>
+                <type>2</type>
+                <family_or_nvt>1.3.6.1.4.1.25623.1.0.100315</family_or_nvt>
+            </nvt_selector>
+            <nvt_selector>
+                <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                <include>1</include>
+                <type>2</type>
+                <family_or_nvt>1.3.6.1.4.1.25623.1.0.14259</family_or_nvt>
+            </nvt_selector>
+        </nvt_selectors>
+    </config>
+</get_config_response>

--- a/selene/tests/policies/example-policy.xml
+++ b/selene/tests/policies/example-policy.xml
@@ -71,6 +71,8 @@
                 <type/>
                 <value>/cgi-bin:/scripts</value>
                 <default>/cgi-bin:/scripts</default>
+                <alt>Paranoid</alt>
+                <alt>Sneaky</alt>
             </preference>
         </preferences>
         <tasks>

--- a/selene/tests/policies/test_get_policy.py
+++ b/selene/tests/policies/test_get_policy.py
@@ -48,6 +48,82 @@ class GetPolicyTestCase(SeleneTestCase):
 
         self.assertResponseAuthenticationRequired(response)
 
+    def test_get_policy_none_fields(self, mock_gmp: GmpMockFactory):
+        mock_gmp.mock_response(
+            'get_policy',
+            '''
+            <get_config_response status="200" status_text="OK">
+                <config id="daba56c8-73ec-11df-a475-002264764cea">
+                    <name>foo</name>
+                </config>
+            </get_config_response>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            '''
+            query {
+               policy (id: "daba56c8-73ec-11df-a475-002264764cea",
+               ) {
+                    name
+                    type
+            	    id
+            	    trash
+                    familyCount
+                    familyGrowing
+                    nvtCount
+                    nvtGrowing
+                    usageType
+                    maxNvtCount
+                    knownNvtCount
+                    predefined
+                    families{
+                        name
+                    }
+                    nvtPreferences{
+                        nvt{
+                            name
+                        }
+                        hrName
+                    }
+                    scannerPreferences{
+                        hrName
+                    }
+                    tasks{
+                        id
+                    }
+                    nvtSelectors{
+                        name
+                    }
+               }
+            }
+            '''
+        )
+
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        policy = json['data']['policy']
+
+        self.assertIsNone(policy['type'])
+        self.assertIsNone(policy['trash'])
+        self.assertIsNone(policy['familyCount'])
+        self.assertIsNone(policy['familyGrowing'])
+        self.assertIsNone(policy['nvtCount'])
+        self.assertIsNone(policy['nvtGrowing'])
+        self.assertIsNone(policy['usageType'])
+        self.assertIsNone(policy['maxNvtCount'])
+        self.assertIsNone(policy['knownNvtCount'])
+        self.assertIsNone(policy['predefined'])
+        self.assertIsNone(policy['families'])
+        self.assertIsNone(policy['nvtPreferences'])
+        self.assertIsNone(policy['scannerPreferences'])
+        self.assertIsNone(policy['tasks'])
+        self.assertIsNone(policy['nvtSelectors'])
+
     def test_get_policy(self, mock_gmp: GmpMockFactory):
         policy_xml_path = CWD / 'example-policy.xml'
         policy_xml_str = policy_xml_path.read_text()
@@ -197,7 +273,7 @@ class GetPolicyTestCase(SeleneTestCase):
                     "type": None,
                     "value": "/cgi-bin:/scripts",
                     "default": "/cgi-bin:/scripts",
-                    "alternativeValues": None,
+                    "alternativeValues": ["Paranoid", "Sneaky"],
                 },
             ],
         )

--- a/selene/tests/policies/test_get_policy.py
+++ b/selene/tests/policies/test_get_policy.py
@@ -91,7 +91,7 @@ class GetPolicyTestCase(SeleneTestCase):
                     scannerPreferences{
                         hrName
                     }
-                    tasks{
+                    audits{
                         id
                     }
                     nvtSelectors{
@@ -121,7 +121,7 @@ class GetPolicyTestCase(SeleneTestCase):
         self.assertIsNone(policy['families'])
         self.assertIsNone(policy['nvtPreferences'])
         self.assertIsNone(policy['scannerPreferences'])
-        self.assertIsNone(policy['tasks'])
+        self.assertIsNone(policy['audits'])
         self.assertIsNone(policy['nvtSelectors'])
 
     def test_get_policy(self, mock_gmp: GmpMockFactory):
@@ -176,7 +176,7 @@ class GetPolicyTestCase(SeleneTestCase):
                         default
                         alternativeValues
                     }
-                    tasks{
+                    audits{
                         id
                         name
                     }
@@ -278,7 +278,7 @@ class GetPolicyTestCase(SeleneTestCase):
             ],
         )
         self.assertEqual(
-            policy['tasks'],
+            policy['audits'],
             [
                 {
                     "id": "49d082ec-73f5-4b3a-75b5-3b9d9e38d079",

--- a/selene/tests/scan_configs/example-scan-config.xml
+++ b/selene/tests/scan_configs/example-scan-config.xml
@@ -1,96 +1,98 @@
-            <get_config_response status="200" status_text="OK">
-                <config id="daba56c8-73ec-11df-a475-002264764cea">
-                    <name>foo</name>
-                    <type>0</type>
-                    <usage_type>scan</usage_type>
-                    <predefined>1</predefined>
-                    <trash>0</trash>
-                    <family_count>2<growing>1</growing></family_count>
-                    <nvt_count>3<growing>0</growing></nvt_count>
-                    <type>0</type>
-                    <usage_type>scan</usage_type>
-                    <families>
-                    <family>
-                        <name>Port scanners</name>
-                        <nvt_count>2</nvt_count>
-                        <max_nvt_count>9</max_nvt_count>
-                        <growing>0</growing>
-                    </family>
-                    <family>
-                        <name>Service detection</name>
-                        <nvt_count>1</nvt_count>
-                        <max_nvt_count>240</max_nvt_count>
-                        <growing>0</growing>
-                    </family>
-                    </families>
-                    <max_nvt_count>249</max_nvt_count>
-                    <known_nvt_count>3</known_nvt_count>
-                    <preferences>
-                        <preference>
-                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
-                                <name>Ping Host</name>
-                            </nvt>
-                            <id>13</id>
-                            <hr_name>Log failed nmap calls</hr_name>
-                            <name>Log failed nmap calls</name>
-                            <type>checkbox</type>
-                            <value>no</value>
-                            <default>no</default>
-                        </preference>
-                        <preference>
-                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
-                                <name>Ping Host</name>
-                            </nvt>
-                            <id>14</id>
-                            <hr_name>nmap timing policy</hr_name>
-                            <name>nmap timing policy</name>
-                            <type>radio</type>
-                            <value>Normal</value>
-                            <alt>Paranoid</alt>
-                            <alt>Sneaky</alt>
-                            <default>Normal</default>
-                        </preference>
-                        <preference>
-                          <nvt oid="">
-                            <name/>
-                          </nvt>
-                          <id/>
-                          <hr_name>auto_enable_dependencies</hr_name>
-                          <name>auto_enable_dependencies</name>
-                          <type/>
-                          <value>1</value>
-                          <default>1</default>
-                        </preference>
-                        <preference>
-                          <nvt oid="">
-                            <name/>
-                          </nvt>
-                          <id/>
-                          <hr_name>cgi_path</hr_name>
-                          <name>cgi_path</name>
-                          <type/>
-                          <value>/cgi-bin:/scripts</value>
-                          <default>/cgi-bin:/scripts</default>
-                        </preference>
-                    </preferences>
-                    <tasks>
-                        <task id="49d082ec-73f5-4b3a-75b5-3b9d9e38d079">
-                            <name>some_name</name>
-                        </task>
-                    </tasks>
-                    <nvt_selectors>
-                        <nvt_selector>
-                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
-                            <include>1</include>
-                            <type>2</type>
-                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.100315</family_or_nvt>
-                        </nvt_selector>
-                        <nvt_selector>
-                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
-                            <include>1</include>
-                            <type>2</type>
-                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.14259</family_or_nvt>
-                        </nvt_selector>
-                    </nvt_selectors>
-                </config>
-            </get_config_response>
+<get_config_response status="200" status_text="OK">
+    <config id="daba56c8-73ec-11df-a475-002264764cea">
+        <name>foo</name>
+        <type>0</type>
+        <usage_type>scan</usage_type>
+        <predefined>1</predefined>
+        <trash>0</trash>
+        <family_count>2<growing>1</growing></family_count>
+        <nvt_count>3<growing>0</growing></nvt_count>
+        <type>0</type>
+        <usage_type>scan</usage_type>
+        <families>
+        <family>
+            <name>Port scanners</name>
+            <nvt_count>2</nvt_count>
+            <max_nvt_count>9</max_nvt_count>
+            <growing>0</growing>
+        </family>
+        <family>
+            <name>Service detection</name>
+            <nvt_count>1</nvt_count>
+            <max_nvt_count>240</max_nvt_count>
+            <growing>0</growing>
+        </family>
+        </families>
+        <max_nvt_count>249</max_nvt_count>
+        <known_nvt_count>3</known_nvt_count>
+        <preferences>
+            <preference>
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                    <name>Ping Host</name>
+                </nvt>
+                <id>13</id>
+                <hr_name>Log failed nmap calls</hr_name>
+                <name>Log failed nmap calls</name>
+                <type>checkbox</type>
+                <value>no</value>
+                <default>no</default>
+            </preference>
+            <preference>
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                    <name>Ping Host</name>
+                </nvt>
+                <id>14</id>
+                <hr_name>nmap timing policy</hr_name>
+                <name>nmap timing policy</name>
+                <type>radio</type>
+                <value>Normal</value>
+                <alt>Paranoid</alt>
+                <alt>Sneaky</alt>
+                <default>Normal</default>
+            </preference>
+            <preference>
+              <nvt oid="">
+                <name/>
+              </nvt>
+              <id/>
+              <hr_name>auto_enable_dependencies</hr_name>
+              <name>auto_enable_dependencies</name>
+              <type/>
+              <value>1</value>
+              <default>1</default>
+            </preference>
+            <preference>
+              <nvt oid="">
+                <name/>
+              </nvt>
+              <id/>
+              <hr_name>cgi_path</hr_name>
+              <name>cgi_path</name>
+              <type/>
+              <value>/cgi-bin:/scripts</value>
+              <default>/cgi-bin:/scripts</default>
+              <alt>Paranoid</alt>
+              <alt>Sneaky</alt>
+            </preference>
+        </preferences>
+        <tasks>
+            <task id="49d082ec-73f5-4b3a-75b5-3b9d9e38d079">
+                <name>some_name</name>
+            </task>
+        </tasks>
+        <nvt_selectors>
+            <nvt_selector>
+                <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                <include>1</include>
+                <type>2</type>
+                <family_or_nvt>1.3.6.1.4.1.25623.1.0.100315</family_or_nvt>
+            </nvt_selector>
+            <nvt_selector>
+                <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                <include>1</include>
+                <type>2</type>
+                <family_or_nvt>1.3.6.1.4.1.25623.1.0.14259</family_or_nvt>
+            </nvt_selector>
+        </nvt_selectors>
+    </config>
+</get_config_response>

--- a/selene/tests/scan_configs/example-scan-config.xml
+++ b/selene/tests/scan_configs/example-scan-config.xml
@@ -1,0 +1,96 @@
+            <get_config_response status="200" status_text="OK">
+                <config id="daba56c8-73ec-11df-a475-002264764cea">
+                    <name>foo</name>
+                    <type>0</type>
+                    <usage_type>scan</usage_type>
+                    <predefined>1</predefined>
+                    <trash>0</trash>
+                    <family_count>2<growing>1</growing></family_count>
+                    <nvt_count>3<growing>0</growing></nvt_count>
+                    <type>0</type>
+                    <usage_type>scan</usage_type>
+                    <families>
+                    <family>
+                        <name>Port scanners</name>
+                        <nvt_count>2</nvt_count>
+                        <max_nvt_count>9</max_nvt_count>
+                        <growing>0</growing>
+                    </family>
+                    <family>
+                        <name>Service detection</name>
+                        <nvt_count>1</nvt_count>
+                        <max_nvt_count>240</max_nvt_count>
+                        <growing>0</growing>
+                    </family>
+                    </families>
+                    <max_nvt_count>249</max_nvt_count>
+                    <known_nvt_count>3</known_nvt_count>
+                    <preferences>
+                        <preference>
+                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                                <name>Ping Host</name>
+                            </nvt>
+                            <id>13</id>
+                            <hr_name>Log failed nmap calls</hr_name>
+                            <name>Log failed nmap calls</name>
+                            <type>checkbox</type>
+                            <value>no</value>
+                            <default>no</default>
+                        </preference>
+                        <preference>
+                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                                <name>Ping Host</name>
+                            </nvt>
+                            <id>14</id>
+                            <hr_name>nmap timing policy</hr_name>
+                            <name>nmap timing policy</name>
+                            <type>radio</type>
+                            <value>Normal</value>
+                            <alt>Paranoid</alt>
+                            <alt>Sneaky</alt>
+                            <default>Normal</default>
+                        </preference>
+                        <preference>
+                          <nvt oid="">
+                            <name/>
+                          </nvt>
+                          <id/>
+                          <hr_name>auto_enable_dependencies</hr_name>
+                          <name>auto_enable_dependencies</name>
+                          <type/>
+                          <value>1</value>
+                          <default>1</default>
+                        </preference>
+                        <preference>
+                          <nvt oid="">
+                            <name/>
+                          </nvt>
+                          <id/>
+                          <hr_name>cgi_path</hr_name>
+                          <name>cgi_path</name>
+                          <type/>
+                          <value>/cgi-bin:/scripts</value>
+                          <default>/cgi-bin:/scripts</default>
+                        </preference>
+                    </preferences>
+                    <tasks>
+                        <task id="49d082ec-73f5-4b3a-75b5-3b9d9e38d079">
+                            <name>some_name</name>
+                        </task>
+                    </tasks>
+                    <nvt_selectors>
+                        <nvt_selector>
+                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                            <include>1</include>
+                            <type>2</type>
+                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.100315</family_or_nvt>
+                        </nvt_selector>
+                        <nvt_selector>
+                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
+                            <include>1</include>
+                            <type>2</type>
+                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.14259</family_or_nvt>
+                        </nvt_selector>
+                    </nvt_selectors>
+                </config>
+            </get_config_response>

--- a/selene/tests/scan_configs/test_get_scan_config.py
+++ b/selene/tests/scan_configs/test_get_scan_config.py
@@ -48,6 +48,82 @@ class GetScanConfigTestCase(SeleneTestCase):
 
         self.assertResponseAuthenticationRequired(response)
 
+    def test_get_scan_config_none_fields(self, mock_gmp: GmpMockFactory):
+        mock_gmp.mock_response(
+            'get_config',
+            '''
+            <get_config_response status="200" status_text="OK">
+                <config id="daba56c8-73ec-11df-a475-002264764cea">
+                    <name>foo</name>
+                </config>
+            </get_config_response>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            '''
+            query {
+               scanConfig (id: "daba56c8-73ec-11df-a475-002264764cea",
+               ) {
+                    name
+                    type
+            	    id
+            	    trash
+                    familyCount
+                    familyGrowing
+                    nvtCount
+                    nvtGrowing
+                    usageType
+                    maxNvtCount
+                    knownNvtCount
+                    predefined
+                    families{
+                        name
+                    }
+                    nvtPreferences{
+                        nvt{
+                            name
+                        }
+                        hrName
+                    }
+                    scannerPreferences{
+                        hrName
+                    }
+                    tasks{
+                        id
+                    }
+                    nvtSelectors{
+                        name
+                    }
+               }
+            }
+            '''
+        )
+
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        scan_config = json['data']['scanConfig']
+
+        self.assertIsNone(scan_config['type'])
+        self.assertIsNone(scan_config['trash'])
+        self.assertIsNone(scan_config['familyCount'])
+        self.assertIsNone(scan_config['familyGrowing'])
+        self.assertIsNone(scan_config['nvtCount'])
+        self.assertIsNone(scan_config['nvtGrowing'])
+        self.assertIsNone(scan_config['usageType'])
+        self.assertIsNone(scan_config['maxNvtCount'])
+        self.assertIsNone(scan_config['knownNvtCount'])
+        self.assertIsNone(scan_config['predefined'])
+        self.assertIsNone(scan_config['families'])
+        self.assertIsNone(scan_config['nvtPreferences'])
+        self.assertIsNone(scan_config['scannerPreferences'])
+        self.assertIsNone(scan_config['tasks'])
+        self.assertIsNone(scan_config['nvtSelectors'])
+
     def test_get_scan_config(self, mock_gmp: GmpMockFactory):
         scan_config_xml_path = CWD / 'example-scan-config.xml'
         scan_config_xml_str = scan_config_xml_path.read_text()
@@ -200,7 +276,7 @@ class GetScanConfigTestCase(SeleneTestCase):
                     "type": None,
                     "value": "/cgi-bin:/scripts",
                     "default": "/cgi-bin:/scripts",
-                    "alternativeValues": None,
+                    "alternativeValues": ["Paranoid", "Sneaky"],
                 },
             ],
         )

--- a/selene/tests/scan_configs/test_get_scan_config.py
+++ b/selene/tests/scan_configs/test_get_scan_config.py
@@ -18,11 +18,15 @@
 
 # pylint: disable=line-too-long
 
+from pathlib import Path
+
 from unittest.mock import patch
 
 from selene.tests import SeleneTestCase, GmpMockFactory
 
 from selene.tests.entity import make_test_get_entity
+
+CWD = Path(__file__).absolute().parent
 
 
 @patch('selene.views.Gmp', new_callable=GmpMockFactory)
@@ -45,85 +49,10 @@ class GetScanConfigTestCase(SeleneTestCase):
         self.assertResponseAuthenticationRequired(response)
 
     def test_get_scan_config(self, mock_gmp: GmpMockFactory):
-        mock_gmp.mock_response(
-            'get_config',
-            '''
-            <get_config_response status="200" status_text="OK">
-                <config id="daba56c8-73ec-11df-a475-002264764cea">
-                    <name>foo</name>
-                    <type>0</type>
-                    <usage_type>scan</usage_type>
-                    <predefined>1</predefined>
-                    <trash>0</trash>
-                    <family_count>2<growing>1</growing></family_count>
-                    <nvt_count>3<growing>0</growing></nvt_count>
-                    <type>0</type>
-                    <usage_type>scan</usage_type>
-                    <families>
-                    <family>
-                        <name>Port scanners</name>
-                        <nvt_count>2</nvt_count>
-                        <max_nvt_count>9</max_nvt_count>
-                        <growing>0</growing>
-                    </family>
-                    <family>
-                        <name>Service detection</name>
-                        <nvt_count>1</nvt_count>
-                        <max_nvt_count>240</max_nvt_count>
-                        <growing>0</growing>
-                    </family>
-                    </families>
-                    <max_nvt_count>249</max_nvt_count>
-                    <known_nvt_count>3</known_nvt_count>
-                    <preferences>
-                        <preference>
-                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
-                                <name>Ping Host</name>
-                            </nvt>
-                            <id>13</id>
-                            <hr_name>Log failed nmap calls</hr_name>
-                            <name>Log failed nmap calls</name>
-                            <type>checkbox</type>
-                            <value>no</value>
-                            <default>no</default>
-                        </preference>
-                        <preference>
-                            <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
-                                <name>Ping Host</name>
-                            </nvt>
-                            <id>14</id>
-                            <hr_name>nmap timing policy</hr_name>
-                            <name>nmap timing policy</name>
-                            <type>radio</type>
-                            <value>Normal</value>
-                            <alt>Paranoid</alt>
-                            <alt>Sneaky</alt>
-                            <default>Normal</default>
-                        </preference>
-                    </preferences>
-                    <tasks>
-                        <task id="49d082ec-73f5-4b3a-75b5-3b9d9e38d079">
-                            <name>some_name</name>
-                        </task>
-                    </tasks>
-                    <nvt_selectors>
-                        <nvt_selector>
-                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
-                            <include>1</include>
-                            <type>2</type>
-                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.100315</family_or_nvt>
-                        </nvt_selector>
-                        <nvt_selector>
-                            <name>f187d4cf-a157-471c-81a6-74990b5da181</name>
-                            <include>1</include>
-                            <type>2</type>
-                            <family_or_nvt>1.3.6.1.4.1.25623.1.0.14259</family_or_nvt>
-                        </nvt_selector>
-                    </nvt_selectors>
-                </config>
-            </get_config_response>
-            ''',
-        )
+        scan_config_xml_path = CWD / 'example-scan-config.xml'
+        scan_config_xml_str = scan_config_xml_path.read_text()
+
+        mock_gmp.mock_response('get_config', scan_config_xml_str)
 
         self.login('foo', 'bar')
 
@@ -150,11 +79,20 @@ class GetScanConfigTestCase(SeleneTestCase):
                         maxNvtCount
                         growing
                     }
-                    preferences{
+                    nvtPreferences{
                         nvt{
                             name
                             id
                         }
+                        hrName
+                        name
+                        id
+                        type
+                        value
+                        default
+                        alternativeValues
+                    }
+                    scannerPreferences{
                         hrName
                         name
                         id
@@ -213,7 +151,7 @@ class GetScanConfigTestCase(SeleneTestCase):
             ],
         )
         self.assertEqual(
-            scan_config['preferences'],
+            scan_config['nvtPreferences'],
             [
                 {
                     "name": "Log failed nmap calls",
@@ -240,6 +178,29 @@ class GetScanConfigTestCase(SeleneTestCase):
                     "value": "Normal",
                     "default": "Normal",
                     "alternativeValues": ["Paranoid", "Sneaky"],
+                },
+            ],
+        )
+        self.assertEqual(
+            scan_config['scannerPreferences'],
+            [
+                {
+                    "name": "auto_enable_dependencies",
+                    "id": None,
+                    "hrName": "auto_enable_dependencies",
+                    "type": None,
+                    "value": "1",
+                    "default": "1",
+                    "alternativeValues": None,
+                },
+                {
+                    "name": "cgi_path",
+                    "id": None,
+                    "hrName": "cgi_path",
+                    "type": None,
+                    "value": "/cgi-bin:/scripts",
+                    "default": "/cgi-bin:/scripts",
+                    "alternativeValues": None,
                 },
             ],
         )


### PR DESCRIPTION
**What**:

* Split Preferences into ScannerPreferences and NVTPreferences in Backend for ScanConfigs and Policies
* Change Task -> Audit in Policies

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* Get rid of conversion in Frontend

<!-- Why are these changes necessary? -->

**How**:

* Checking if NVT ID is set:
  * IF yes: NVT Preference
  * IF not: Scanner Preference

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
