### PR TITLE
Rename allow_simultaneous_ips also for modify target

### DIFF
--- a/selene/schema/targets/mutations.py
+++ b/selene/schema/targets/mutations.py
@@ -291,9 +291,10 @@ class ModifyTargetInput(graphene.InputObjectType):
     )
     alive_test = graphene.String(description="Which alive test to use.")
     allow_simultaneous_ips = graphene.Boolean(
+        name="allowSimultaneousIPs",
         description=(
             "Whether to scan multiple IPs of the same host simultaneously."
-        )
+        ),
     )
     reverse_lookup_only = graphene.Boolean(
         description="Whether to scan only hosts that have names."

--- a/selene/tests/targets/test_modify_target.py
+++ b/selene/tests/targets/test_modify_target.py
@@ -73,7 +73,7 @@ class ModifyTargetTestCase(SeleneTestCase):
                     snmpCredentialId: "{self.snmp_credential_id}",
                     esxiCredentialId: "{self.esxi_credential_id}",
                     aliveTest: "icmp ping",
-                    allowSimultaneousIps: false,
+                    allowSimultaneousIPs: false,
                     reverseLookupUnify: false,
                 }}) {{
                     ok
@@ -207,4 +207,56 @@ class ModifyTargetTestCase(SeleneTestCase):
             reverse_lookup_only=None,
             reverse_lookup_unify=None,
             port_list_id=str(self.port_list_id),
+        )
+
+    def test_modify_target_allow_simultaneous_ips(
+        self, mock_gmp: GmpMockFactory
+    ):
+        mock_gmp.mock_response(
+            'modify_target',
+            '''
+            <modify_target_response status="200" status_text="OK" />
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            f'''
+            mutation {{
+                modifyTarget(input: {{
+                    id: "{self.target_id}",
+                    name: "bar",
+                    allowSimultaneousIPs: true,
+                }}) {{
+                    ok
+                }}
+            }}
+            '''
+        )
+
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        ok = json['data']['modifyTarget']['ok']
+
+        self.assertEqual(ok, True)
+
+        mock_gmp.gmp_protocol.modify_target.assert_called_with(
+            str(self.target_id),
+            alive_test=None,
+            hosts=None,
+            exclude_hosts=None,
+            comment=None,
+            ssh_credential_id=None,
+            name="bar",
+            ssh_credential_port=None,
+            smb_credential_id=None,
+            snmp_credential_id=None,
+            esxi_credential_id=None,
+            allow_simultaneous_ips=True,
+            reverse_lookup_only=None,
+            reverse_lookup_unify=None,
+            port_list_id=None,
         )


### PR DESCRIPTION
**What**:

Use allowSimultaneousIPs also for modify target.

**Why**:

Was missing from the previous PR.

**How**:

Added another test for modifying allowSimultaneousIPs explicitly and run all tests.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
