### PR TITLE
Target credentials as object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ $ cd hyperion && git log
 - Revisit feed status object types [#95](https://github.com/greenbone/hyperion/pull/95)
 - Introduce QoDType enum and use common QoD class for NVT and Result [#109](https://github.com/greenbone/hyperion/pull/109)
 - Revisit result object type [#92](https://github.com/greenbone/hyperion/pull/92)
-- Revisit target object type, queries and mutations [#97](https://github.com/greenbone/hyperion/pull/97), [106](https://github.com/greenbone/hyperion/pull/106)
+- Revisit target object type, queries and mutations 
+  [#97](https://github.com/greenbone/hyperion/pull/97),
+  [#106](https://github.com/greenbone/hyperion/pull/106),
+  [#113](https://github.com/greenbone/hyperion/pull/113)
 - Explicitly implement audit subobjects [#26](https://github.com/greenbone/hyperion/pull/26)
 - For all NVT related Entities we use `id` instead of `oid` now, so every Entity uses `id` now. [#15](https://github.com/greenbone/hyperion/pull/15)
 - Use `next` instead of `latest` `python-gvm` version for development. [#15](https://github.com/greenbone/hyperion/pull/15)

--- a/selene/errors.py
+++ b/selene/errors.py
@@ -34,6 +34,7 @@ class ErrorCode(AutoName):
     UNKNOWN = auto()
     AUTHENTICATION_REQUIRED = auto()
     AUTHENTICATION_FAILED = auto()
+    INVALID_REQUEST = auto()
 
     def __str__(self):
         if isinstance(self.value, str):
@@ -53,3 +54,7 @@ class AuthenticationRequired(SeleneError):
 
 class AuthenticationFailed(SeleneError):
     errorCode = ErrorCode.AUTHENTICATION_FAILED
+
+
+class InvalidRequest(SeleneError):
+    errorCode = ErrorCode.INVALID_REQUEST

--- a/selene/schema/targets/fields.py
+++ b/selene/schema/targets/fields.py
@@ -55,6 +55,36 @@ class TargetTask(BaseObjectType):
     """ A Task referenced by a Target via name and id """
 
 
+class TargetCredentials(graphene.ObjectType):
+    """ Credentials of a Target to be used in a scan"""
+
+    ssh = graphene.Field(
+        TargetSSHCredential,
+        description="Credential to be used for login via SSH",
+    )
+    smb = graphene.Field(
+        TargetCredential, description="Credential to be used for SMB logins"
+    )
+    esxi = graphene.Field(
+        TargetCredential, description="Credential for login into ESXi servers"
+    )
+    snmp = graphene.Field(
+        TargetCredential, description="Credential to be used for SNMP logins"
+    )
+
+    def resolve_ssh(root, _info):
+        return root.find('ssh_credential')
+
+    def resolve_smb(root, _info):
+        return root.find('smb_credential')
+
+    def resolve_esxi(root, _info):
+        return root.find('esxi_credential')
+
+    def resolve_snmp(root, _info):
+        return root.find('snmp_credential')
+
+
 class Target(EntityObjectType):
     """Target ObjectType"""
 
@@ -75,11 +105,6 @@ class Target(EntityObjectType):
     port_list = graphene.Field(
         PortList, description="Port list to use for the target"
     )
-
-    ssh_credential = graphene.Field(TargetSSHCredential)
-    smb_credential = graphene.Field(TargetCredential)
-    esxi_credential = graphene.Field(TargetCredential)
-    snmp_credential = graphene.Field(TargetCredential)
 
     alive_test = graphene.Field(
         AliveTest, description="Which alive test to use"
@@ -104,9 +129,16 @@ class Target(EntityObjectType):
         description="List of tasks that use the target",
     )
 
+    credentials = graphene.Field(
+        TargetCredentials, description="Credentials to use for the scan target"
+    )
+
     def resolve_hosts(root, _info):
         hosts = get_text_from_element(root, 'hosts')
         return csv_to_list(hosts)
+
+    def resolve_credentials(root, _info):
+        return root
 
     def resolve_exclude_hosts(root, _info):
         exclude_hosts = get_text_from_element(root, 'exclude_hosts')
@@ -117,18 +149,6 @@ class Target(EntityObjectType):
 
     def resolve_port_list(root, _info):
         return root.find("port_list")
-
-    def resolve_ssh_credential(root, _info):
-        return root.find('ssh_credential')
-
-    def resolve_smb_credential(root, _info):
-        return root.find('smb_credential')
-
-    def resolve_esxi_credential(root, _info):
-        return root.find('esxi_credential')
-
-    def resolve_snmp_credential(root, _info):
-        return root.find('snmp_credential')
 
     def resolve_alive_test(root, _info):
         return get_text_from_element(root, 'alive_tests')

--- a/selene/schema/targets/mutations.py
+++ b/selene/schema/targets/mutations.py
@@ -20,6 +20,8 @@
 
 import graphene
 
+from selene.errors import InvalidRequest
+
 from selene.schema.entities import (
     create_delete_by_ids_mutation,
     create_delete_by_filter_mutation,
@@ -137,6 +139,14 @@ class CreateTarget(graphene.Mutation):
             input_object.credentials is not None
             and input_object.credentials.ssh is not None
         ):
+            if (
+                input_object.credentials.ssh.port
+                and not input_object.credentials.ssh.ssh_id
+            ):
+                raise InvalidRequest(
+                    "Setting a SSH credential port requires a SSH credential id"
+                )
+
             ssh_credential_id = str(input_object.credentials.ssh.ssh_id)
             ssh_credential_port = input_object.credentials.ssh.port
         else:
@@ -280,6 +290,14 @@ class ModifyTarget(graphene.Mutation):
             input_object.credentials is not None
             and input_object.credentials.ssh is not None
         ):
+            if (
+                input_object.credentials.ssh.port
+                and not input_object.credentials.ssh.ssh_id
+            ):
+                raise InvalidRequest(
+                    "Setting a SSH credential port requires a SSH credential id"
+                )
+
             ssh_credential_id = str(input_object.credentials.ssh.ssh_id)
             ssh_credential_port = input_object.credentials.ssh.port
         else:

--- a/selene/schema/targets/mutations.py
+++ b/selene/schema/targets/mutations.py
@@ -35,6 +35,38 @@ from selene.schema.utils import (
 )
 
 
+class SSHTargetCredentialInput(graphene.InputObjectType):
+    ssh_id = graphene.UUID(
+        name="id", description="UUID of a ssh credential to use on target"
+    )
+    port = graphene.Int(description="The port to use for ssh credential")
+
+
+class TargetCredentialInput(graphene.InputObjectType):
+    credential_id = graphene.UUID(
+        name="id", description="UUID of a credential to use on target"
+    )
+
+
+class TargetCredentialsInput(graphene.InputObjectType):
+    ssh = graphene.Field(
+        SSHTargetCredentialInput,
+        description="SSH credential to use on target",
+    )
+    smb = graphene.Field(
+        TargetCredentialInput,
+        description="SMB credential to use on target",
+    )
+    snmp = graphene.Field(
+        TargetCredentialInput,
+        description="SNMP credential to use on target",
+    )
+    esxi = graphene.Field(
+        TargetCredentialInput,
+        description="ESXi credential to use on target",
+    )
+
+
 class CreateTargetInput(graphene.InputObjectType):
     """Input object for createTarget"""
 
@@ -51,17 +83,8 @@ class CreateTargetInput(graphene.InputObjectType):
         required=True, description="UUID of the port list to use on target"
     )
     comment = graphene.String(description="Comment for the target")
-    ssh_credential_id = graphene.UUID(
-        description="UUID of a ssh credential to use on target"
-    )
-    ssh_credential_port = graphene.Int(
-        description="The port to use for ssh credential"
-    )
-    smb_credential_id = graphene.UUID(
-        description="UUID of a smb credential to use on target"
-    )
-    snmp_credential_id = graphene.UUID(
-        description="UUID of a snmp credential to use on target"
+    credentials = graphene.Field(
+        TargetCredentialsInput, description="Credentials to use for the target"
     )
     esxi_credential_id = graphene.UUID(
         description="UUID of a esxi credential to use on target"
@@ -110,25 +133,41 @@ class CreateTarget(graphene.Mutation):
         hosts = input_object.hosts
         exclude_hosts = input_object.exclude_hosts
 
-        if input_object.ssh_credential_id is not None:
-            ssh_credential_id = str(input_object.ssh_credential_id)
-            ssh_credential_port = input_object.ssh_credential_port
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.ssh is not None
+        ):
+            ssh_credential_id = str(input_object.credentials.ssh.ssh_id)
+            ssh_credential_port = input_object.credentials.ssh.port
         else:
             ssh_credential_id = None
             ssh_credential_port = None
 
-        if input_object.smb_credential_id is not None:
-            smb_credential_id = str(input_object.smb_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.smb is not None
+        ):
+            smb_credential_id = str(input_object.credentials.smb.credential_id)
         else:
             smb_credential_id = None
 
-        if input_object.snmp_credential_id is not None:
-            snmp_credential_id = str(input_object.snmp_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.snmp is not None
+        ):
+            snmp_credential_id = str(
+                input_object.credentials.snmp.credential_id
+            )
         else:
             snmp_credential_id = None
 
-        if input_object.esxi_credential_id is not None:
-            esxi_credential_id = str(input_object.esxi_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.esxi is not None
+        ):
+            esxi_credential_id = str(
+                input_object.credentials.esxi.credential_id
+            )
         else:
             esxi_credential_id = None
 
@@ -162,38 +201,6 @@ class CreateTarget(graphene.Mutation):
         return CreateTarget(target_id=resp.get('id'))
 
 
-class ModifySSHTargetCredentialInput(graphene.InputObjectType):
-    ssh_id = graphene.UUID(
-        name="id", description="UUID of a ssh credential to use on target"
-    )
-    port = graphene.Int(description="The port to use for ssh credential")
-
-
-class ModifyTargetCredentialInput(graphene.InputObjectType):
-    credential_id = graphene.UUID(
-        name="id", description="UUID of a credential to use on target"
-    )
-
-
-class ModifyTargetCredentialsInput(graphene.InputObjectType):
-    ssh = graphene.Field(
-        ModifySSHTargetCredentialInput,
-        description="SSH credential to use on target",
-    )
-    smb = graphene.Field(
-        ModifyTargetCredentialInput,
-        description="SMB credential to use on target",
-    )
-    snmp = graphene.Field(
-        ModifyTargetCredentialInput,
-        description="SNMP credential to use on target",
-    )
-    esxi = graphene.Field(
-        ModifyTargetCredentialInput,
-        description="ESXi credential to use on target",
-    )
-
-
 class ModifyTargetInput(graphene.InputObjectType):
     """Input object for modifyTarget"""
 
@@ -210,7 +217,7 @@ class ModifyTargetInput(graphene.InputObjectType):
     )
     comment = graphene.String(description="Comment for the target")
     credentials = graphene.Field(
-        ModifyTargetCredentialsInput,
+        TargetCredentialsInput,
         description="Credentials to set on the target",
     )
     alive_test = graphene.Field(

--- a/selene/schema/targets/mutations.py
+++ b/selene/schema/targets/mutations.py
@@ -162,6 +162,38 @@ class CreateTarget(graphene.Mutation):
         return CreateTarget(target_id=resp.get('id'))
 
 
+class ModifySSHTargetCredentialInput(graphene.InputObjectType):
+    ssh_id = graphene.UUID(
+        name="id", description="UUID of a ssh credential to use on target"
+    )
+    port = graphene.Int(description="The port to use for ssh credential")
+
+
+class ModifyTargetCredentialInput(graphene.InputObjectType):
+    credential_id = graphene.UUID(
+        name="id", description="UUID of a credential to use on target"
+    )
+
+
+class ModifyTargetCredentialsInput(graphene.InputObjectType):
+    ssh = graphene.Field(
+        ModifySSHTargetCredentialInput,
+        description="SSH credential to use on target",
+    )
+    smb = graphene.Field(
+        ModifyTargetCredentialInput,
+        description="SMB credential to use on target",
+    )
+    snmp = graphene.Field(
+        ModifyTargetCredentialInput,
+        description="SNMP credential to use on target",
+    )
+    esxi = graphene.Field(
+        ModifyTargetCredentialInput,
+        description="ESXi credential to use on target",
+    )
+
+
 class ModifyTargetInput(graphene.InputObjectType):
     """Input object for modifyTarget"""
 
@@ -177,20 +209,9 @@ class ModifyTargetInput(graphene.InputObjectType):
         graphene.String, description="List of hosts to exclude from scan"
     )
     comment = graphene.String(description="Comment for the target")
-    ssh_credential_id = graphene.UUID(
-        description="UUID of a ssh credential to use on target"
-    )
-    ssh_credential_port = graphene.Int(
-        description="The port to use for ssh credential"
-    )
-    smb_credential_id = graphene.UUID(
-        description="UUID of a smb credential to use on target"
-    )
-    snmp_credential_id = graphene.UUID(
-        description="UUID of a snmp credential to use on target"
-    )
-    esxi_credential_id = graphene.UUID(
-        description="UUID of a esxi credential to use on target"
+    credentials = graphene.Field(
+        ModifyTargetCredentialsInput,
+        description="Credentials to set on the target",
     )
     alive_test = graphene.Field(
         AliveTest, description="Which alive test to use"
@@ -248,25 +269,41 @@ class ModifyTarget(graphene.Mutation):
         else:
             exclude_hosts = None
 
-        if input_object.ssh_credential_id is not None:
-            ssh_credential_id = str(input_object.ssh_credential_id)
-            ssh_credential_port = input_object.ssh_credential_port
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.ssh is not None
+        ):
+            ssh_credential_id = str(input_object.credentials.ssh.ssh_id)
+            ssh_credential_port = input_object.credentials.ssh.port
         else:
             ssh_credential_id = None
             ssh_credential_port = None
 
-        if input_object.smb_credential_id is not None:
-            smb_credential_id = str(input_object.smb_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.smb is not None
+        ):
+            smb_credential_id = str(input_object.credentials.smb.credential_id)
         else:
             smb_credential_id = None
 
-        if input_object.snmp_credential_id is not None:
-            snmp_credential_id = str(input_object.snmp_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.snmp is not None
+        ):
+            snmp_credential_id = str(
+                input_object.credentials.snmp.credential_id
+            )
         else:
             snmp_credential_id = None
 
-        if input_object.esxi_credential_id is not None:
-            esxi_credential_id = str(input_object.esxi_credential_id)
+        if (
+            input_object.credentials is not None
+            and input_object.credentials.esxi is not None
+        ):
+            esxi_credential_id = str(
+                input_object.credentials.esxi.credential_id
+            )
         else:
             esxi_credential_id = None
 

--- a/selene/tests/targets/test_create_target.py
+++ b/selene/tests/targets/test_create_target.py
@@ -161,29 +161,9 @@ class CreateTargetTestCase(SeleneTestCase):
             '''
         )
 
-        json = response.json()
-
-        self.assertResponseNoErrors(response)
-
-        uuid = json['data']['createTarget']['id']
-
-        self.assertEqual(uuid, str(self.target_id))
-
-        mock_gmp.gmp_protocol.create_target.assert_called_with(
-            "bar",
-            alive_test=AliveTest.ICMP_PING,  # pylint: disable=no-member
-            hosts=["127.0.0.1"],
-            exclude_hosts=None,
-            comment=None,
-            ssh_credential_id=None,
-            ssh_credential_port=None,
-            smb_credential_id=None,
-            snmp_credential_id=None,
-            esxi_credential_id=None,
-            allow_simultaneous_ips=None,
-            reverse_lookup_only=None,
-            reverse_lookup_unify=None,
-            port_list_id=str(self.port_list_id),
+        self.assertResponseHasErrorMessage(
+            response,
+            "Setting a SSH credential port requires a SSH credential id",
         )
 
     def test_create_target_missing_port_list_id(self, mock_gmp: GmpMockFactory):

--- a/selene/tests/targets/test_create_target.py
+++ b/selene/tests/targets/test_create_target.py
@@ -73,11 +73,21 @@ class CreateTargetTestCase(SeleneTestCase):
                 createTarget(input: {{
                     name: "bar",
                     hosts: ["127.0.0.1", "192.168.10.130"],
-                    sshCredentialId: "{self.ssh_credential_id}",
-                    sshCredentialPort: 33,
-                    smbCredentialId: "{self.smb_credential_id}",
-                    snmpCredentialId: "{self.snmp_credential_id}",
-                    esxiCredentialId: "{self.esxi_credential_id}",
+                    credentials: {{
+                        ssh: {{
+                            id: "{self.ssh_credential_id}",
+                            port: 33,
+                        }}
+                        smb: {{
+                            id: "{self.smb_credential_id}",
+                        }}
+                        snmp: {{
+                            id: "{self.snmp_credential_id}",
+                        }}
+                        esxi: {{
+                            id: "{self.esxi_credential_id}",
+                        }}
+                    }}
                     excludeHosts: ["1.3.3.7", "lorem"],
                     aliveTest: ICMP_PING,
                     allowSimultaneousIPs: true,
@@ -115,7 +125,9 @@ class CreateTargetTestCase(SeleneTestCase):
             port_list_id=str(self.port_list_id),
         )
 
-    def test_nullify_ssh_cred_port(self, mock_gmp: GmpMockFactory):
+    def test_ssh_credential_port_without_credential_id(
+        self, mock_gmp: GmpMockFactory
+    ):
         mock_gmp.mock_response(
             'create_target',
             f'''
@@ -135,7 +147,11 @@ class CreateTargetTestCase(SeleneTestCase):
                 createTarget(input: {{
                     name: "bar",
                     hosts: ["127.0.0.1"],
-                    sshCredentialPort: 22,
+                    credentials: {{
+                        ssh: {{
+                            port: 22,
+                        }}
+                    }}
                     portListId: "{self.port_list_id}"
                     aliveTest: ICMP_PING,
                 }}) {{
@@ -192,11 +208,21 @@ class CreateTargetTestCase(SeleneTestCase):
                     createTarget(input: {{
                         name: "bar",
                         hosts: ["127.0.0.1", "192.168.10.130"],
-                        sshCredentialId: "{self.ssh_credential_id}",
-                        sshCredentialPort: 33,
-                        smbCredentialId: "{self.smb_credential_id}",
-                        snmpCredentialId: "{self.snmp_credential_id}",
-                        esxiCredentialId: "{self.esxi_credential_id}",
+                        credentials: {{
+                            ssh: {{
+                                id: "{self.ssh_credential_id}",
+                                port: 33,
+                            }}
+                            smb: {{
+                                id: "{self.smb_credential_id}",
+                            }}
+                            snmp: {{
+                                id: "{self.snmp_credential_id}",
+                            }}
+                            esxi: {{
+                                id: "{self.esxi_credential_id}",
+                            }}
+                        }}
                         excludeHosts: ["1.3.3.7", "lorem"],
                         aliveTest: ICMP_PING,
                         reverseLookupUnify: false,

--- a/selene/tests/targets/test_get_target.py
+++ b/selene/tests/targets/test_get_target.py
@@ -98,22 +98,24 @@ class TargetTestCase(SeleneTestCase):
                     hosts
                     hostCount
                     excludeHosts
-                    sshCredential {
-                        id
-                        name
-                        port
-                    }
-                    smbCredential {
-                        id
-                        name
-                    }
-                    esxiCredential {
-                        id
-                        name
-                    }
-                    snmpCredential {
-                        id
-                        name
+                    credentials {
+                        ssh {
+                            id
+                            name
+                            port
+                        }
+                        smb {
+                            id
+                            name
+                        }
+                        esxi {
+                            id
+                            name
+                        }
+                        snmp {
+                            id
+                            name
+                        }
                     }
                     portList {
                         id
@@ -143,26 +145,26 @@ class TargetTestCase(SeleneTestCase):
         self.assertEqual(target['excludeHosts'], ['192.168.10.9'])
         self.assertEqual(target['hostCount'], 1)
         self.assertEqual(
-            target['sshCredential']['id'],
+            target['credentials']['ssh']['id'],
             '33d0cd82-57c6-11e1-8ed1-4061823cc51a',
         )
-        self.assertEqual(target['sshCredential']['name'], 'baz')
-        self.assertEqual(target['sshCredential']['port'], 42)
+        self.assertEqual(target['credentials']['ssh']['name'], 'baz')
+        self.assertEqual(target['credentials']['ssh']['port'], 42)
         self.assertEqual(
-            target['smbCredential']['id'],
+            target['credentials']['smb']['id'],
             '33d0cd82-57c6-11e1-8ed1-4061823cc51b',
         )
-        self.assertEqual(target['smbCredential']['name'], 'baz')
+        self.assertEqual(target['credentials']['smb']['name'], 'baz')
         self.assertEqual(
-            target['esxiCredential']['id'],
+            target['credentials']['esxi']['id'],
             '33d0cd82-57c6-11e1-8ed1-4061823cc51c',
         )
-        self.assertEqual(target['esxiCredential']['name'], 'qux')
+        self.assertEqual(target['credentials']['esxi']['name'], 'qux')
         self.assertEqual(
-            target['snmpCredential']['id'],
+            target['credentials']['snmp']['id'],
             '33d0cd82-57c6-11e1-8ed1-4061823cc51d',
         )
-        self.assertEqual(target['snmpCredential']['name'], 'quux')
+        self.assertEqual(target['credentials']['snmp']['name'], 'quux')
         self.assertEqual(
             target['portList']['id'], '33d0cd82-57c6-11e1-8ed1-406186ea4fc5'
         )

--- a/selene/tests/targets/test_modify_target.py
+++ b/selene/tests/targets/test_modify_target.py
@@ -66,11 +66,22 @@ class ModifyTargetTestCase(SeleneTestCase):
                     id: "{self.target_id}",
                     name: "bar",
                     hosts: ["127.0.0.1", "192.168.10.130"],
-                    sshCredentialId: "{self.ssh_credential_id}",
-                    sshCredentialPort: 33,
-                    smbCredentialId: "{self.smb_credential_id}",
-                    snmpCredentialId: "{self.snmp_credential_id}",
-                    esxiCredentialId: "{self.esxi_credential_id}",
+                    credentials: {{
+                        ssh: {{
+                            id: "{self.ssh_credential_id}",
+                            port: 33,
+                        }},
+                        smb: {{
+                            id: "{self.smb_credential_id}",
+                        }},
+                        snmp: {{
+                            id: "{self.snmp_credential_id}",
+                        }}
+                        esxi: {{
+                            id: "{self.esxi_credential_id}",
+                        }},
+
+                    }},
                     aliveTest: ICMP_PING,
                     allowSimultaneousIPs: false,
                     reverseLookupUnify: false,
@@ -173,7 +184,6 @@ class ModifyTargetTestCase(SeleneTestCase):
                 modifyTarget(input: {{
                     id: "{self.target_id}",
                     name: "bar",
-                    sshCredentialPort: 22,
                     portListId: "{str(self.port_list_id)}"
                 }}) {{
                     ok

--- a/selene/tests/targets/test_modify_target.py
+++ b/selene/tests/targets/test_modify_target.py
@@ -269,3 +269,45 @@ class ModifyTargetTestCase(SeleneTestCase):
             reverse_lookup_unify=None,
             port_list_id=None,
         )
+
+    def test_ssh_credential_port_without_credential_id(
+        self, mock_gmp: GmpMockFactory
+    ):
+        mock_gmp.mock_response(
+            'modify_target',
+            f'''
+            <modify_target_response
+                id="{self.target_id}"
+                status="200"
+                status_text="OK"
+            />
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            f'''
+            mutation {{
+                modifyTarget(input: {{
+                    id: "{self.target_id}",
+                    name: "bar",
+                    hosts: ["127.0.0.1"],
+                    credentials: {{
+                        ssh: {{
+                            port: 22,
+                        }}
+                    }}
+                    portListId: "{self.port_list_id}"
+                    aliveTest: ICMP_PING,
+                }}) {{
+                   ok
+                }}
+            }}
+            '''
+        )
+
+        self.assertResponseHasErrorMessage(
+            response,
+            "Setting a SSH credential port requires a SSH credential id",
+        )

--- a/selene/tests/targets/test_modify_target.py
+++ b/selene/tests/targets/test_modify_target.py
@@ -118,7 +118,7 @@ class ModifyTargetTestCase(SeleneTestCase):
             port_list_id=None,
         )
 
-    def test_nullify_config_default_alive_test(self, mock_gmp: GmpMockFactory):
+    def test_modify_target_alive_test(self, mock_gmp: GmpMockFactory):
         mock_gmp.mock_response(
             'modify_target',
             '''


### PR DESCRIPTION
**What**:

Use credentials as sub-object in target queries and mutations.

**Why**:

Make the API more consistent and more readable for possible credential additions in the future.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [x] Documentation
