### PR TITLE
Fix typos.

### DIFF
--- a/selene/schema/reports/fields.py
+++ b/selene/schema/reports/fields.py
@@ -209,7 +209,7 @@ class ReportModel:
 class Report(graphene.ObjectType):
     """
     The Report object type. It can be accessed with getReport()
-    and getReports(). It contains some general Report informations
+    and getReports(). It contains some general Report information
 
     Args:
         timestamp (DateTime): Timestamp for this report
@@ -225,7 +225,7 @@ class Report(graphene.ObjectType):
         scan_start (DateTime)
         scan_end (DateTime)
         error_count (int): Error count
-        errors = (List(Error)): Errors occured
+        errors = (List(Error)): Errors occurred
         report_format (str): Format from this report
     """
 

--- a/selene/schema/roles/mutations.py
+++ b/selene/schema/roles/mutations.py
@@ -152,7 +152,7 @@ class ModifyRoleInput(graphene.InputObjectType):
     Args:
         role_id (str): UUID of role to modify.
         comment (str, optional): Name of role.
-        name (str, optinal): Comment on role.
+        name (str, optional): Comment on role.
         users (List[str], optional): List of user names.
     """
 

--- a/selene/schema/users/mutations.py
+++ b/selene/schema/users/mutations.py
@@ -346,7 +346,7 @@ class ModifyUserInput(graphene.InputObjectType):
         name (str, optional): The name of the user.
         comment (str, optional): The comment on the user.
         password (str, optional): Password of the user. Auth Sources need to
-            be set with seperately if needed.
+            be set with separately if needed.
         role_ids (List(UUID)): A list of role UUIDs for the user.
         group_ids (List(UUID)): A list of group UUIDs for the user.
         hosts (List(str)): A list of hosts for the user.


### PR DESCRIPTION
From codespell:

```
./hyperion/selene/schema/roles/mutations.py:155: optinal ==> optional
./hyperion/selene/schema/reports/fields.py:212: informations ==> information
./hyperion/selene/schema/reports/fields.py:228: occured ==> occurred
./hyperion/selene/schema/users/mutations.py:349: seperately ==> separately
```
