### PR TITLE
Use graphdoc for GraphQL schema documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ $ cd hyperion && git log
 
 ### Added
 
+- Use [#graphdoc](https://github.com/wallee94/graphdoc) as schema documentation tool [#124](https://github.com/greenbone/hyperion/pull/124)
 - Add csv_to_list function [#96](https://github.com/greenbone/hyperion/pull/96)
 - Add `new_severity` to override mutations [#85](https://github.com/greenbone/hyperion/pull/85)
 - Query for target tasks in single query [#78](https://github.com/greenbone/hyperion/pull/78)

--- a/poetry.lock
+++ b/poetry.lock
@@ -265,6 +265,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "graphdoc"
+version = "0.2.4"
+description = "Generate HTML docs for your GraphQL API"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+graphql-core = ">=2.1.0,<4"
+Jinja2 = ">=2"
+markdown2 = ">=2"
+
+[[package]]
 name = "graphene"
 version = "2.1.8"
 description = "GraphQL Framework for Python"
@@ -380,7 +393,7 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 name = "jinja2"
 version = "2.11.3"
 description = "A very fast and expressive template engine."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -413,10 +426,18 @@ htmlsoup = ["beautifulsoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
+name = "markdown2"
+version = "2.4.0"
+description = "A fast and complete Python implementation of Markdown"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[[package]]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
@@ -862,7 +883,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ccd2edefa340935e8fc2b57e56a6f940bd5c4d9aa10abb9967c98102d007c7e2"
+content-hash = "dfa5f532bbeb789db9dc499f0aa8bf135d4a5c62ff9eb86234ed995e77a0d3e2"
 
 [metadata.files]
 alabaster = [
@@ -1057,6 +1078,10 @@ docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
+graphdoc = [
+    {file = "graphdoc-0.2.4-py3-none-any.whl", hash = "sha256:8dad6581deba89d69df761bab451ab09b0a2b99b47bcc4bf1697cca8789f501b"},
+    {file = "graphdoc-0.2.4.tar.gz", hash = "sha256:f848bb8d3c49d5f690ae6a7610b96034beadf159d5f1a77a98101f31afc26db0"},
+]
 graphene = [
     {file = "graphene-2.1.8-py2.py3-none-any.whl", hash = "sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896"},
     {file = "graphene-2.1.8.tar.gz", hash = "sha256:2cbe6d4ef15cfc7b7805e0760a0e5b80747161ce1b0f990dfdc0d2cf497c12f9"},
@@ -1154,6 +1179,10 @@ lxml = [
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
+]
+markdown2 = [
+    {file = "markdown2-2.4.0-py2.py3-none-any.whl", hash = "sha256:8d4ef4a2d090c99532069c4611a9a2b9bea6ae1fa29b6c3727c95d1e31a8f6c5"},
+    {file = "markdown2-2.4.0.tar.gz", hash = "sha256:28d769f0e544e6f68f684f01e9b186747b079a6927d9ca77ebc8c640a2829b1b"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ graphene-django = "^2.9.0"
 python-gvm = "^21.4.0"
 django-cors-headers = "^3.2.1"
 lxml = "^4.6.3"
+graphdoc = "^0.2.4"
 
 
 [tool.poetry.dev-dependencies]

--- a/selene/urls.py
+++ b/selene/urls.py
@@ -20,9 +20,10 @@ from django.urls import path
 
 from django.views.generic.base import RedirectView
 
-from selene.views import main
+from selene.views import main, GraphqlDocView
 
 urlpatterns = [  # pylint: disable=invalid-name
     path('', RedirectView.as_view(pattern_name='selene-graphql')),
     path('graphql/', main(), name='selene-graphql'),
+    path('docs/', GraphqlDocView.as_view(), name='selene-graphql-docs'),
 ]

--- a/selene/views.py
+++ b/selene/views.py
@@ -18,11 +18,14 @@
 
 from typing import Dict, Tuple
 
+import graphdoc
+
 from graphene_django.views import GraphQLView
 from graphql.error import GraphQLError
 
 from django.conf import settings
 from django.http import HttpResponse
+from django.views import View
 
 from gvm.connections import UnixSocketConnection
 from gvm.errors import GvmError, GvmResponseError, GvmClientError
@@ -119,3 +122,9 @@ class SeleneView(GraphQLView):
 
 def main():
     return SeleneView.as_view(graphiql=True, schema=schema)
+
+
+class GraphqlDocView(View):
+    def get(self, _request):
+        html = graphdoc.to_doc(schema)
+        return HttpResponse(html, content_type='text/html')


### PR DESCRIPTION
**What**:

Use https://github.com/wallee94/graphdoc for GraphQL schema documentation.
The documentation will be available when running hyperion on the `selene/docs/` URL.
The documentation is generated the fly during each request. To get an updated doc it is just necessary to refresh the browser window.

**Why**:

It is easy to add and seems to work very well. 

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [x] Documentation
