### PR TITLE
Add new base classes for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ $ cd hyperion && git log
 
 ### Added
 
+- Introduced new base classes for queries [#126](https://github.com/greenbone/hyperion/pull/126)
 - Use [#graphdoc](https://github.com/wallee94/graphdoc) as schema documentation tool [#124](https://github.com/greenbone/hyperion/pull/124)
 - Add csv_to_list function [#96](https://github.com/greenbone/hyperion/pull/96)
 - Add `new_severity` to override mutations [#85](https://github.com/greenbone/hyperion/pull/85)

--- a/selene/schema/base.py
+++ b/selene/schema/base.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=no-self-argument, no-member
 
+from typing import Dict
+
 import graphene
 
 from selene.schema.parser import parse_uuid
@@ -76,3 +78,32 @@ class CACertificateMixin:
 
     def resolve_expiration_time(root, _info):
         return get_datetime_from_element(root, 'expiration_time')
+
+
+class ObjectTypeQueryMixin:
+    object_type: graphene.ObjectType = None
+    kwargs: Dict[str, graphene.Field] = None
+
+    def __init__(self, description: str = None, **kwargs):
+        if description is None:
+            description = self.__doc__
+
+        kwargs.update(self.get_kwargs())
+
+        super().__init__(
+            self.object_type,
+            resolver=self.resolve,
+            description=description,
+            **kwargs,
+        )
+
+    def get_kwargs(self):
+        return self.kwargs or {}
+
+
+class SingleObjectQuery(ObjectTypeQueryMixin, graphene.Field):
+    pass
+
+
+class ListQuery(ObjectTypeQueryMixin, graphene.List):
+    pass

--- a/selene/schema/feeds/queries.py
+++ b/selene/schema/feeds/queries.py
@@ -15,13 +15,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import graphene
-
+from selene.schema.base import ListQuery, SingleObjectQuery
 from selene.schema.feeds.fields import Feed, FeedType
 from selene.schema.utils import get_gmp, require_authentication, XmlElement
 
 
-class GetFeed(graphene.Field):
+class GetFeed(SingleObjectQuery):
     """Gets a single feed
 
     Example:
@@ -56,10 +55,10 @@ class GetFeed(graphene.Field):
 
     """
 
-    def __init__(self):
-        super().__init__(
-            Feed, feed_type=FeedType(required=True), resolver=self.resolve
-        )
+    object_type = Feed
+    kwargs = {
+        'feed_type': FeedType(required=True, description="Requested Feed type")
+    }
 
     @staticmethod
     @require_authentication
@@ -72,7 +71,7 @@ class GetFeed(graphene.Field):
         return xml.find('feed')
 
 
-class GetFeeds(graphene.List):
+class GetFeeds(ListQuery):
     """Gets a list of all feeds
 
     Args:
@@ -124,8 +123,7 @@ class GetFeeds(graphene.List):
 
     """
 
-    def __init__(self):
-        super().__init__(Feed, resolver=self.resolve)
+    object_type = Feed
 
     @staticmethod
     @require_authentication


### PR DESCRIPTION
**What**:

Introduce SingleObjectQuery and ListQuery as new base classes for our
queries (more explicit for fields that act as query).

**Why**:

With using this new base classes the queries can be implemented in a more
declarative way instead of heaving to always override the constructor.
See the also included examples for GetFeed and GetFeeds.

**How**:

`poetry run python manage.py test --settings=selene.tests.settings selene.tests.feeds`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
