### PR TITLE
Avoid disabling linter feature

### DIFF
--- a/selene/schema/alerts/fields.py
+++ b/selene/schema/alerts/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -97,6 +95,7 @@ class AlertTask(BaseObjectType):
 class AlertFilter(BaseObjectType):
     trash = graphene.Int()
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_int_from_element(root, 'trash')
 
@@ -108,6 +107,7 @@ class PropertyData(graphene.ObjectType):
     name = graphene.String()
     value = graphene.String()
 
+    @staticmethod
     def resolve_value(root, _info):
         name = root.find('name')
         return name.tail
@@ -117,9 +117,11 @@ class AlertProperty(graphene.ObjectType):
     property_type = graphene.String(name='type')
     data = graphene.List(PropertyData)
 
+    @staticmethod
     def resolve_property_type(root, _info):
         return get_text(root)
 
+    @staticmethod
     def resolve_data(root, _info):
         return root.findall('data')
 
@@ -135,14 +137,17 @@ class Alert(EntityObjectType):
     event = graphene.Field(AlertProperty)
     alert_filter = graphene.Field(AlertFilter, name="filter")
 
+    @staticmethod
     def resolve_active(root, _info):
         return get_boolean_from_element(root, 'active')
 
+    @staticmethod
     def resolve_tasks(root, _info):
         tasks = root.find('tasks')
         if len(tasks) == 0:
             return None
         return tasks.findall('task')
 
+    @staticmethod
     def resolve_alert_filter(root, _info):
         return root.find('filter')

--- a/selene/schema/alerts/mutations.py
+++ b/selene/schema/alerts/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -199,8 +197,9 @@ class CreateAlert(graphene.Mutation):
 
     alert_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         if input_object.event_data is not None:
@@ -310,8 +309,9 @@ class ModifyAlert(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         if input_object.event_data is not None:
@@ -375,8 +375,9 @@ class CloneAlert(graphene.Mutation):
 
     alert_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, copy_id):
+    def mutate(_root, info, copy_id):
         gmp = get_gmp(info)
         resp = gmp.clone_alert(str(copy_id))
         return CloneAlert(alert_id=resp.get('id'))
@@ -399,8 +400,9 @@ class TestAlert(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, alert_id):
+    def mutate(_root, info, alert_id):
         gmp = get_gmp(info)
         gmp.test_alert(str(alert_id))
         return TestAlert(ok=True)

--- a/selene/schema/alerts/queries.py
+++ b/selene/schema/alerts/queries.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/audits/fields.py
+++ b/selene/schema/audits/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.resolver import find_resolver, int_resolver, text_resolver
@@ -46,9 +44,11 @@ class AuditReportsCounts(graphene.ObjectType):
         description="Number of finished reports for the audit"
     )
 
+    @staticmethod
     def resolve_finished(parent, _info):
         return get_text_from_element(parent, 'finished')
 
+    @staticmethod
     def resolve_total(parent, _info):
         return get_text(parent)
 
@@ -74,28 +74,34 @@ class AuditLastReport(graphene.ObjectType):
         AuditComplianceCount, description='Compliance status for this audit'
     )
 
+    @staticmethod
     def resolve_compliance_count(root, _info):
         report = get_subelement(root, 'report')
         return get_subelement(report, 'compliance_count')
 
+    @staticmethod
     def resolve_uuid(parent, _info):
         report = parent.find('report')
         uuid = report.get('id')
         return uuid
 
+    @staticmethod
     def resolve_severity(parent, _info):
         report = parent.find('report')
         severity = report.find('severity')
         return get_text(severity)
 
+    @staticmethod
     def resolve_timestamp(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'timestamp')
 
+    @staticmethod
     def resolve_scan_start(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_end')
@@ -111,18 +117,22 @@ class AuditCurrentReport(graphene.ObjectType):
     scan_end = graphene.DateTime()
     timestamp = graphene.DateTime()
 
+    @staticmethod
     def resolve_uuid(parent, _info):
         report = parent.find('report')
         return report.get('id')
 
+    @staticmethod
     def resolve_scan_start(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_end')
 
+    @staticmethod
     def resolve_timestamp(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'timestamp')
@@ -141,11 +151,13 @@ class AuditReports(graphene.ObjectType):
     class Meta:
         default_resolver = find_resolver
 
+    @staticmethod
     def resolve_counts(root, _info):
         return get_subelement(root, 'report_count')
 
 
 class AuditResultsCounts(BaseCounts):
+    @staticmethod
     def resolve_current(current: int, _info):
         return current
 
@@ -153,6 +165,7 @@ class AuditResultsCounts(BaseCounts):
 class AuditResults(graphene.ObjectType):
     counts = graphene.Field(AuditResultsCounts)
 
+    @staticmethod
     def resolve_counts(result_count: XmlElement, _info):
         current = get_text(result_count)
         return parse_int(current)
@@ -162,6 +175,7 @@ class AuditSubObjectType(BaseObjectType):
 
     trash = graphene.Boolean()
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_boolean_from_element(root, 'trash')
 
@@ -172,6 +186,7 @@ class AuditPolicy(AuditSubObjectType):
         name="type", description="Type of the scan config"
     )
 
+    @staticmethod
     def resolve_scan_config_type(parent, _info):
         return get_int_from_element(parent, 'type')
 
@@ -181,6 +196,7 @@ class AuditScanner(AuditSubObjectType):
         ScannerType, name="type", description="Type of the scanner"
     )
 
+    @staticmethod
     def resolve_scanner_type(root, _info):
         return get_text_from_element(root, 'type')
 
@@ -193,6 +209,7 @@ class AuditSchedule(AuditSubObjectType):
     duration = graphene.Int()
     timezone = graphene.String()
 
+    @staticmethod
     def resolve_duration(root, _info):
         return get_int_from_element(root, 'duration')
 
@@ -205,9 +222,11 @@ class AuditPreference(graphene.ObjectType):
     name = graphene.String()
     value = graphene.String()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'scanner_name')
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -217,15 +236,18 @@ class AuditObservers(graphene.ObjectType):
     groups = graphene.List(BaseObjectType)
     roles = graphene.List(BaseObjectType)
 
+    @staticmethod
     def resolve_users(root, _info):
         user_string = get_text(root)
         if not user_string:
             return None
         return user_string.split(' ')
 
+    @staticmethod
     def resolve_groups(root, _info):
         return root.findall('group')
 
+    @staticmethod
     def resolve_roles(root, _info):
         return root.findall('role')
 
@@ -264,53 +286,68 @@ class Audit(EntityObjectType):
     reports = graphene.Field(AuditReports)
     results = graphene.Field(AuditResults)
 
+    @staticmethod
     def resolve_average_duration(root, _info):
         return get_int_from_element(root, 'average_duration')
 
+    @staticmethod
     def resolve_trend(root, _info):
         return get_text_from_element(root, 'trend')
 
+    @staticmethod
     def resolve_status(root, _info):
         return get_text_from_element(root, 'status')
 
+    @staticmethod
     def resolve_alterable(root, _info):
         return get_boolean_from_element(root, 'alterable')
 
+    @staticmethod
     def resolve_hosts_ordering(root, _info):
         return get_text_from_element(root, 'hosts_ordering')
 
+    @staticmethod
     def resolve_progress(root, _info):
         return get_int_from_element(root, 'progress')
 
+    @staticmethod
     def resolve_policy(root, _info):
         return get_sub_element_if_id_available(root, 'config')
 
+    @staticmethod
     def resolve_target(root, _info):
         return get_sub_element_if_id_available(root, 'target')
 
+    @staticmethod
     def resolve_scanner(root, _info):
         return get_sub_element_if_id_available(root, 'scanner')
 
+    @staticmethod
     def resolve_alerts(root, _info):
         alerts = root.findall('alert')
         if not alerts:
             return None
         return alerts
 
+    @staticmethod
     def resolve_schedule(root, _info):
         return get_sub_element_if_id_available(root, 'schedule')
 
+    @staticmethod
     def resolve_schedule_periods(root, _info):
         return get_int_from_element(root, 'schedule_periods')
 
+    @staticmethod
     def resolve_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is None:
             return None
         return preferences.findall('preference')
 
+    @staticmethod
     def resolve_results(root, _info):
         return get_subelement(root, 'result_count')
 
+    @staticmethod
     def resolve_reports(root, _info):
         return root

--- a/selene/schema/audits/mutations.py
+++ b/selene/schema/audits/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -59,8 +57,9 @@ class CloneAudit(graphene.Mutation):
 
     audit_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, audit_id):
+    def mutate(_root, info, audit_id):
         gmp = get_gmp(info)
         elem = gmp.clone_audit(str(audit_id))
         return CloneAudit(audit_id=elem.get('id'))
@@ -81,8 +80,9 @@ class DeleteAudit(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, audit_id):
+    def mutate(_root, info, audit_id):
         gmp = get_gmp(info)
         gmp.delete_audit(str(audit_id))
         return DeleteAudit(ok=True)
@@ -135,8 +135,9 @@ class CreateContainerAudit(graphene.Mutation):
 
     audit_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object: CreateContainerAuditInput):
+    def mutate(_root, info, input_object: CreateContainerAuditInput):
         gmp = get_gmp(info)
 
         resp = gmp.create_container_audit(
@@ -264,8 +265,9 @@ class CreateAudit(graphene.Mutation):
 
     audit_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         alterable = input_object.alterable
@@ -478,8 +480,9 @@ class ModifyAudit(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         audit_id = str(input_object.audit_id)
         name = input_object.name
@@ -589,8 +592,9 @@ class StartAudit(graphene.Mutation):
 
     report_id = graphene.UUID()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, audit_id):
+    def mutate(_root, info, audit_id):
         gmp = get_gmp(info)
         resp = gmp.start_audit(str(audit_id))
 
@@ -613,8 +617,9 @@ class StopAudit(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, audit_id):
+    def mutate(_root, info, audit_id):
         gmp = get_gmp(info)
         resp = gmp.stop_audit(str(audit_id))
         status = int(resp.get('status'))
@@ -637,8 +642,9 @@ class ResumeAudit(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, audit_id):
+    def mutate(_root, info, audit_id):
         gmp = get_gmp(info)
         resp = gmp.resume_audit(str(audit_id))
         status = int(resp.get('status'))

--- a/selene/schema/audits/queries.py
+++ b/selene/schema/audits/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/authentication.py
+++ b/selene/schema/authentication.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from datetime import timedelta
 
 import graphene

--- a/selene/schema/authentication_methods/fields.py
+++ b/selene/schema/authentication_methods/fields.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
 import graphene
 
 from selene.schema.base import CACertificateMixin
@@ -38,25 +37,31 @@ class CaCertificate(CACertificateMixin, graphene.ObjectType):
         )
     )
 
+    @staticmethod
     def resolve_certificate(root: XmlElement, _info):
         return get_text_from_element(root, "value")
 
+    @staticmethod
     def resolve_time_status(root: XmlElement, _info):
         cert_info = root.find('certificate_info')
         return get_text_from_element(cert_info, 'time_status')
 
+    @staticmethod
     def resolve_md5_fingerprint(root: XmlElement, _info):
         cert_info = root.find('certificate_info')
         return get_text_from_element(cert_info, 'md5_fingerprint')
 
+    @staticmethod
     def resolve_issuer(root: XmlElement, _info):
         cert_info = root.find('certificate_info')
         return get_text_from_element(cert_info, 'issuer')
 
+    @staticmethod
     def resolve_activation_time(root: XmlElement, _info):
         cert_info = root.find('certificate_info')
         return get_datetime_from_element(cert_info, 'activation_time')
 
+    @staticmethod
     def resolve_expiration_time(root: XmlElement, _info):
         cert_info = root.find('certificate_info')
         return get_datetime_from_element(cert_info, 'expiration_time')
@@ -77,6 +82,7 @@ class LDAPAuthenticationSettings(graphene.ObjectType):
         description="True if the LDAP authentication is in use"
     )
 
+    @staticmethod
     def resolve_auth_dn(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -84,6 +90,7 @@ class LDAPAuthenticationSettings(graphene.ObjectType):
                 return setting.find('value').text
         return None
 
+    @staticmethod
     def resolve_enable(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -91,6 +98,7 @@ class LDAPAuthenticationSettings(graphene.ObjectType):
                 return setting.find('value').text == 'true'
         return None
 
+    @staticmethod
     def resolve_host(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -98,6 +106,7 @@ class LDAPAuthenticationSettings(graphene.ObjectType):
                 return setting.find('value').text
         return None
 
+    @staticmethod
     def resolve_ca_certificate(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -119,6 +128,7 @@ class RADIUSAuthenticationSettings(graphene.ObjectType):
         description="Secret key used for connecting to the RADIUS server"
     )
 
+    @staticmethod
     def resolve_enable(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -126,6 +136,7 @@ class RADIUSAuthenticationSettings(graphene.ObjectType):
                 return setting.find('value').text == 'true'
         return None
 
+    @staticmethod
     def resolve_host(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text
@@ -133,6 +144,7 @@ class RADIUSAuthenticationSettings(graphene.ObjectType):
                 return setting.find('value').text
         return None
 
+    @staticmethod
     def resolve_secret_key(group: XmlElement, _info):
         for setting in group:
             key = setting.find('key').text

--- a/selene/schema/authentication_methods/queries.py
+++ b/selene/schema/authentication_methods/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.authentication_methods.fields import (

--- a/selene/schema/base.py
+++ b/selene/schema/base.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
+# pylint: disable=no-member
 
 from typing import Dict
 
@@ -29,6 +29,7 @@ from selene.schema.utils import get_datetime_from_element, get_text_from_element
 class NameObjectTypeMixin:
     name = graphene.String(description='Name of the object')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -38,6 +39,7 @@ class UUIDObjectTypeMixin:
         name='id', description='Unique identifier of the object'
     )
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
@@ -67,15 +69,19 @@ class CACertificateMixin:
         description="Datetime when the CA certificate will expire"
     )
 
+    @staticmethod
     def resolve_md5_fingerprint(root, _info):
         return get_text_from_element(root, 'md5_fingerprint')
 
+    @staticmethod
     def resolve_issuer(root, _info):
         return get_text_from_element(root, 'issuer')
 
+    @staticmethod
     def resolve_activation_time(root, _info):
         return get_datetime_from_element(root, 'activation_time')
 
+    @staticmethod
     def resolve_expiration_time(root, _info):
         return get_datetime_from_element(root, 'expiration_time')
 

--- a/selene/schema/base.py
+++ b/selene/schema/base.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
 from typing import Dict
 
 import graphene

--- a/selene/schema/capabilities.py
+++ b/selene/schema/capabilities.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import (

--- a/selene/schema/cert_bund_advisories/fields.py
+++ b/selene/schema/cert_bund_advisories/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -34,12 +32,15 @@ class CertBundAdvisoryRevision(graphene.ObjectType):
     description = graphene.String()
     number = graphene.Int()
 
+    @staticmethod
     def resolve_date(root, _info):
         return get_datetime_from_element(root, 'Date')
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'Description')
 
+    @staticmethod
     def resolve_number(root, _info):
         return get_int_from_element(root, 'Number')
 
@@ -48,9 +49,11 @@ class CertBundAdvisoryInfo(graphene.ObjectType):
     info_issuer = graphene.String()
     info_url = graphene.String()
 
+    @staticmethod
     def resolve_info_issuer(root, _info):
         return root.get('Info_Issuer')
 
+    @staticmethod
     def resolve_info_url(root, _info):
         return root.get('Info_URL')
 
@@ -77,24 +80,30 @@ class CertBundAdvisory(EntityObjectType):
     risk = graphene.String()
     software = graphene.String()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_update_time(root, _info):
         return get_datetime_from_element(root, 'update_time')
 
+    @staticmethod
     def resolve_max_cvss(root, _info):
         cert_bund = root.find('cert_bund_adv')
         return get_text_from_element(cert_bund, 'max_cvss')
 
+    @staticmethod
     def resolve_score(root, _info):
         cert_bund = root.find('cert_bund_adv')
         return get_text_from_element(cert_bund, 'score')
 
+    @staticmethod
     def resolve_cve_refs(root, _info):
         cert_bund = root.find('cert_bund_adv')
         return get_int_from_element(cert_bund, 'cve_refs')
 
+    @staticmethod
     def resolve_cves(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
@@ -105,6 +114,7 @@ class CertBundAdvisory(EntityObjectType):
             return cves
         return None
 
+    @staticmethod
     def resolve_categories(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
@@ -115,12 +125,15 @@ class CertBundAdvisory(EntityObjectType):
             return categories
         return None
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root.find('cert_bund_adv'), 'summary')
 
+    @staticmethod
     def resolve_title(root, _info):
         return get_text_from_element(root.find('cert_bund_adv'), 'title')
 
+    @staticmethod
     def resolve_infos(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
@@ -131,11 +144,13 @@ class CertBundAdvisory(EntityObjectType):
                     return infos.findall('Info')
         return None
 
+    @staticmethod
     def resolve_effect(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Effect')
 
+    @staticmethod
     def resolve_remote_attack(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
@@ -143,41 +158,49 @@ class CertBundAdvisory(EntityObjectType):
                 return True
         return False
 
+    @staticmethod
     def resolve_platform(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Platform')
 
+    @staticmethod
     def resolve_reference_id(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Ref_Num')
 
+    @staticmethod
     def resolve_reference_number(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return adv.find('Ref_Num').get('update')
 
+    @staticmethod
     def resolve_reference_source(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Reference_Source')
 
+    @staticmethod
     def resolve_reference_url(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Reference_URL')
 
+    @staticmethod
     def resolve_revisions(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return adv.find('RevisionHistory').findall('Revision')
 
+    @staticmethod
     def resolve_risk(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:
             return get_text_from_element(adv, 'Risk')
 
+    @staticmethod
     def resolve_software(root, _info):
         adv = root.find('cert_bund_adv/raw_data/Advisory')
         if adv is not None:

--- a/selene/schema/cert_bund_advisories/mutations.py
+++ b/selene/schema/cert_bund_advisories/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,

--- a/selene/schema/cert_bund_advisories/queries.py
+++ b/selene/schema/cert_bund_advisories/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from graphql import ResolveInfo

--- a/selene/schema/cpes/fields.py
+++ b/selene/schema/cpes/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -35,9 +33,11 @@ class CveRef(graphene.ObjectType):
         SeverityType, description="Severity of referenced CVE"
     )
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, '{*}cvss/{*}base_metrics/{*}score')
 
@@ -59,36 +59,43 @@ class CPE(EntityObjectType):
     )
     status = graphene.String(description="Latest CPE status")
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_update_time(root, _info):
         return get_datetime_from_element(root, 'update_time')
 
+    @staticmethod
     def resolve_title(root, _info):
         cpe = root.find('cpe')
         if cpe is not None:
             return get_text_from_element(cpe, 'title')
         return None
 
+    @staticmethod
     def resolve_nvd_id(root, _info):
         cpe = root.find('cpe')
         if cpe is not None:
             return get_text_from_element(cpe, 'nvd_id')
         return None
 
+    @staticmethod
     def resolve_score(root, _info):
         cpe = root.find('cpe')
         if cpe is not None:
             return get_text_from_element(cpe, 'score')
         return None
 
+    @staticmethod
     def resolve_cve_ref_count(root, _info):
         cpe = root.find('cpe')
         if cpe is not None:
             return get_int_from_element(cpe, 'cve_refs')
         return None
 
+    @staticmethod
     def resolve_cve_refs(root, _info):
         cves = root.find('cpe/cves')
         if cves is not None:
@@ -97,12 +104,14 @@ class CPE(EntityObjectType):
                 return cves
         return None
 
+    @staticmethod
     def resolve_deprecated_by(root, _info):
         cpe_item = root.find('cpe/raw_data/{*}cpe-item')
         if cpe_item is not None:
             return cpe_item.get('deprecated_by')
         return None
 
+    @staticmethod
     def resolve_status(root, _info):
         cpe = root.find('cpe')
         if cpe is not None:

--- a/selene/schema/cpes/mutations.py
+++ b/selene/schema/cpes/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,

--- a/selene/schema/cpes/queries.py
+++ b/selene/schema/cpes/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from graphql import ResolveInfo

--- a/selene/schema/credentials/fields.py
+++ b/selene/schema/credentials/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -72,39 +70,49 @@ class Credential(EntityObjectType):
     certificate = graphene.String()
     public_key = graphene.String()
 
+    @staticmethod
     def resolve_login(root, _info):
         return get_text_from_element(root, 'login')
 
+    @staticmethod
     def resolve_allow_insecure(root, _info):
         return get_boolean_from_element(root, 'allow_insecure')
 
+    @staticmethod
     def resolve_credential_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_auth_algorithm(root, _info):
         return get_text_from_element(root, 'auth_algorithm')
 
+    @staticmethod
     def resolve_privacy_algorithm(root, _info):
         privacy = get_subelement(root, 'privacy')
         return get_text_from_element(privacy, 'algorithm')
 
+    @staticmethod
     def resolve_scanners(root, _info):
         scanners = root.find('scanners')
         if len(scanners) == 0:
             return None
         return scanners.findall('scanner')
 
+    @staticmethod
     def resolve_targets(root, _info):
         targets = root.find('targets')
         if len(targets) == 0:
             return None
         return targets.findall('target')
 
+    @staticmethod
     def resolve_credential_package(root, _info):
         return get_text_from_element(root, 'package')
 
+    @staticmethod
     def resolve_certificate(root, _info):
         return get_text_from_element(root, 'certificate')
 
+    @staticmethod
     def resolve_public_key(root, _info):
         return get_text_from_element(root, 'public_key')

--- a/selene/schema/credentials/mutations.py
+++ b/selene/schema/credentials/mutations.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
-
 import graphene
 
 
@@ -72,8 +69,9 @@ class CloneCredential(graphene.Mutation):
 
     credential_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, credential_id):
+    def mutate(_root, info, credential_id):
         gmp = get_gmp(info)
         elem = gmp.clone_credential(str(credential_id))
         return CloneCredential(credential_id=elem.get('id'))
@@ -188,8 +186,9 @@ class CreateCredential(graphene.Mutation):
 
     credential_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         credential_type = CredentialType.get(input_object.credential_type)
@@ -352,8 +351,9 @@ class ModifyCredential(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         credential_id = str(input_object.credential_id)
         name = input_object.name
 

--- a/selene/schema/credentials/queries.py
+++ b/selene/schema/credentials/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/cves/fields.py
+++ b/selene/schema/cves/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -35,27 +33,35 @@ class CVSSv2Vector(graphene.ObjectType):
     base_score = graphene.Field(SeverityType)
     vector = graphene.String()
 
+    @staticmethod
     def resolve_access_vector(root, _info):
         return get_text_from_element(root, '{*}access-vector')
 
+    @staticmethod
     def resolve_access_complexity(root, _info):
         return get_text_from_element(root, '{*}access-complexity')
 
+    @staticmethod
     def resolve_authentication(root, _info):
         return get_text_from_element(root, '{*}authentication')
 
+    @staticmethod
     def resolve_confidentiality(root, _info):
         return get_text_from_element(root, '{*}confidentiality-impact')
 
+    @staticmethod
     def resolve_integrity(root, _info):
         return get_text_from_element(root, '{*}integrity-impact')
 
+    @staticmethod
     def resolve_availability(root, _info):
         return get_text_from_element(root, '{*}availability-impact')
 
+    @staticmethod
     def resolve_base_score(root, _info):
         return get_text_from_element(root, '{*}score')
 
+    @staticmethod
     def resolve_vector(root, _info):
         return get_text_from_element(root, '{*}vector-string')
 
@@ -72,33 +78,43 @@ class CVSSv3Vector(graphene.ObjectType):
     base_score = graphene.Field(SeverityType)
     vector = graphene.String()
 
+    @staticmethod
     def resolve_attack_vector(root, _info):
         return get_text_from_element(root, '{*}attack-vector')
 
+    @staticmethod
     def resolve_attack_complexity(root, _info):
         return get_text_from_element(root, '{*}attack-complexity')
 
+    @staticmethod
     def resolve_privileges_required(root, _info):
         return get_text_from_element(root, '{*}privileges-required')
 
+    @staticmethod
     def resolve_user_interaction(root, _info):
         return get_text_from_element(root, '{*}user-interaction')
 
+    @staticmethod
     def resolve_scope(root, _info):
         return get_text_from_element(root, '{*}scope')
 
+    @staticmethod
     def resolve_confidentiality(root, _info):
         return get_text_from_element(root, '{*}confidentiality-impact')
 
+    @staticmethod
     def resolve_integrity(root, _info):
         return get_text_from_element(root, '{*}integrity-impact')
 
+    @staticmethod
     def resolve_availability(root, _info):
         return get_text_from_element(root, '{*}availability-impact')
 
+    @staticmethod
     def resolve_base_score(root, _info):
         return get_text_from_element(root, '{*}base-score')
 
+    @staticmethod
     def resolve_vector(root, _info):
         return get_text_from_element(root, '{*}vector-string')
 
@@ -107,9 +123,11 @@ class NvtRef(graphene.ObjectType):
     oid = graphene.String(name='id', description='NVT reference oid')
     name = graphene.String(description='NVT reference oid')
 
+    @staticmethod
     def resolve_oid(root, _info):
         return root.get('oid')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -119,12 +137,15 @@ class CertRef(graphene.ObjectType):
     title = graphene.String(description='Cert reference title')
     cert_type = graphene.String(name='type', description='Cert reference type')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_title(root, _info):
         return get_text_from_element(root, 'title')
 
+    @staticmethod
     def resolve_cert_type(root, _info):
         return root.get('type')
 
@@ -134,15 +155,18 @@ class Refs(graphene.ObjectType):
     link = graphene.String()
     reference = graphene.String()
 
+    @staticmethod
     def resolve_source(root, _info):
         return get_text_from_element(root, '{*}source')
 
+    @staticmethod
     def resolve_link(root, _info):
         ref = root.find('{*}reference')
         if ref is not None:
             return ref.get('href')
         return None
 
+    @staticmethod
     def resolve_reference(root, _info):
         return get_text_from_element(root, '{*}reference')
 
@@ -160,39 +184,47 @@ class CVE(EntityObjectType):
     nvt_refs = graphene.List(NvtRef)
     cert_refs = graphene.List(CertRef)
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_update_time(root, _info):
         return get_datetime_from_element(root, 'update_time')
 
+    @staticmethod
     def resolve_cvss_vector(root, _info):
         cve = root.find('cve')
         if cve is not None:
             return get_text_from_element(cve, 'cvss_vector')
         return None
 
+    @staticmethod
     def resolve_cvss_v2_vector(root, _info):
         entry = root.find('cve/raw_data/{*}entry')
         if entry is not None:
             return entry.find('{*}cvss/{*}base_metrics')
         return None
 
+    @staticmethod
     def resolve_cvss_v3_vector(root, _info):
         entry = root.find('cve/raw_data/{*}entry')
         if entry is not None:
             return entry.find('{*}cvss3/{*}base_metrics')
         return None
 
+    @staticmethod
     def resolve_score(root, _info):
         cve = root.find('cve')
         if cve is not None:
             return get_text_from_element(cve, 'score')
         return None
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root.find('cve'), 'description')
 
+    @staticmethod
     def resolve_products(root, _info):
         cve = root.find('cve')
         if cve is not None:
@@ -201,18 +233,21 @@ class CVE(EntityObjectType):
                 return products.rstrip().split(' ')
         return None
 
+    @staticmethod
     def resolve_nvt_refs(root, _info):
         nvts = root.find('cve/nvts')
         if nvts is not None:
             return nvts.findall('nvt')
         return None
 
+    @staticmethod
     def resolve_cert_refs(root, _info):
         cert = root.find('cve/cert')
         if cert is not None:
             return cert.findall('cert_ref')
         return None
 
+    @staticmethod
     def resolve_refs(root, _info):
         entry = root.find('cve/raw_data/{*}entry')
         if entry is not None:

--- a/selene/schema/cves/mutations.py
+++ b/selene/schema/cves/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,

--- a/selene/schema/cves/queries.py
+++ b/selene/schema/cves/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from graphql import ResolveInfo

--- a/selene/schema/dfn_cert_advisories/fields.py
+++ b/selene/schema/dfn_cert_advisories/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member, not-an-iterable
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -39,11 +37,13 @@ class DFNCertAdvisoryAuthor(graphene.ObjectType):
     name = graphene.String()
     uri = graphene.String()
 
+    @staticmethod
     def resolve_name(root, _info):
         for elem in root:
             if 'name' in elem.tag:
                 return elem.text
 
+    @staticmethod
     def resolve_uri(root, _info):
         for elem in root:
             if 'uri' in elem.tag:
@@ -62,42 +62,50 @@ class DFNCertAdvisory(EntityObjectType):
     cves = graphene.List(graphene.String)
     link = graphene.String()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_update_time(root, _info):
         return get_datetime_from_element(root, 'update_time')
 
+    @staticmethod
     def resolve_title(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv')
         if dfn_cert_adv is not None:
             return get_text_from_element(dfn_cert_adv, 'title')
         return None
 
+    @staticmethod
     def resolve_summary(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv')
         if dfn_cert_adv is not None:
             return get_text_from_element(dfn_cert_adv, 'summary').strip()
         return None
 
+    @staticmethod
     def resolve_max_cvss(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv')
         if dfn_cert_adv is not None:
             return get_text_from_element(dfn_cert_adv, 'max_cvss')
         return None
 
+    @staticmethod
     def resolve_score(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv')
         if dfn_cert_adv is not None:
             return get_text_from_element(dfn_cert_adv, 'score')
         return None
 
+    @staticmethod
     def resolve_cve_refs(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv')
         if dfn_cert_adv is not None:
             return get_int_from_element(dfn_cert_adv, 'cve_refs')
         return None
 
+    @staticmethod
     def resolve_cves(root, _info):
         dfn_cert_adv = root.find('dfn_cert_adv/raw_data/{*}entry')
         if dfn_cert_adv is not None:
@@ -106,12 +114,14 @@ class DFNCertAdvisory(EntityObjectType):
                 return [cve.text for cve in cves]
         return None
 
+    @staticmethod
     def resolve_author(root, _info):
         author = root.find('dfn_cert_adv/raw_data/{*}entry/{*}author')
         if author is not None:
             return author
         return None
 
+    @staticmethod
     def resolve_link(root, _info):
         link = root.find('dfn_cert_adv/raw_data/{*}entry/{*}link')
         if link is not None:

--- a/selene/schema/dfn_cert_advisories/mutations.py
+++ b/selene/schema/dfn_cert_advisories/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,

--- a/selene/schema/dfn_cert_advisories/queries.py
+++ b/selene/schema/dfn_cert_advisories/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from graphql import ResolveInfo

--- a/selene/schema/entities.py
+++ b/selene/schema/entities.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from typing import List
 from lxml import etree
 
@@ -53,8 +51,9 @@ def create_export_by_filter_mutation(
     """
 
     class ExportByFilter(graphene.Mutation, AbstractExportByFilter):
+        @staticmethod
         @require_authentication
-        def mutate(root, info, filter_string: str = None):
+        def mutate(_root, info, filter_string: str = None):
             gmp = get_gmp(info)
 
             get_entities = (
@@ -107,8 +106,9 @@ def create_export_by_ids_mutation(
     """
 
     class ExportByIds(graphene.Mutation, AbstractExportByIds):
+        @staticmethod
         @require_authentication
-        def mutate(root, info, entity_ids: str = None):
+        def mutate(_root, info, entity_ids: str = None):
             gmp = get_gmp(info)
 
             get_entities = (
@@ -166,9 +166,10 @@ def create_delete_by_filter_mutation(
     """
 
     class DeleteByFilter(graphene.Mutation, AbstractDeleteByFilter):
+        @staticmethod
         @require_authentication
         def mutate(
-            root, info, filter_string: str = None, ultimate: bool = None
+            _root, info, filter_string: str = None, ultimate: bool = None
         ):
             gmp = get_gmp(info)
 
@@ -238,8 +239,9 @@ def create_delete_by_ids_mutation(
     """
 
     class DeleteByIds(graphene.Mutation, AbstractDeleteByIds):
+        @staticmethod
         @require_authentication
-        def mutate(root, info, entity_ids=None, ultimate=None):
+        def mutate(_root, info, entity_ids=None, ultimate=None):
             gmp = get_gmp(info)
 
             # gmp delete function to call later.
@@ -310,8 +312,9 @@ def create_export_secinfos_by_ids_mutation(
     """
 
     class ExportSecInfoByIds(graphene.Mutation, AbstractExportSecInfosByIds):
+        @staticmethod
         @require_authentication
-        def mutate(root, info, entity_ids: List[str] = None):
+        def mutate(_root, info, entity_ids: List[str] = None):
             gmp = get_gmp(info)
 
             get_entities = getattr(gmp, 'get_info_list')

--- a/selene/schema/entity.py
+++ b/selene/schema/entity.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
 import graphene
 
 from selene.schema.base import BaseObjectType, NameObjectTypeMixin
@@ -36,9 +35,11 @@ class EntityUserTags(graphene.ObjectType):
     count = graphene.Int(description='Number of tags')
     tags = graphene.List(Tag, description='List of tags')
 
+    @staticmethod
     def resolve_count(root, _info):
         return get_int_from_element(root, 'count')
 
+    @staticmethod
     def resolve_tags(root, _info):
         return root.findall('tag')
 
@@ -56,9 +57,11 @@ class CreationModifactionObjectTypeMixin:
         description='Date and time the entity was last modified '
     )
 
+    @staticmethod
     def resolve_creation_time(root, _info):
         return get_datetime_from_element(root, 'creation_time')
 
+    @staticmethod
     def resolve_modification_time(root, _info):
         return get_datetime_from_element(root, 'modification_time')
 
@@ -66,6 +69,7 @@ class CreationModifactionObjectTypeMixin:
 class OwnerObjectTypeMixin:
     owner = graphene.String(description='Name of the user owning the entity')
 
+    @staticmethod
     def resolve_owner(root, _info):
         return get_owner(root)
 
@@ -74,6 +78,7 @@ class CommentObjectTypeMixin:
 
     comment = graphene.String(description='Additional comment about the entity')
 
+    @staticmethod
     def resolve_comment(root, _info):
         return get_text_from_element(root, 'comment')
 
@@ -85,6 +90,7 @@ class PermissionObjectTypeMixin:
         description='Permissions of the current user on the entity',
     )
 
+    @staticmethod
     def resolve_permissions(root, _info):
         permissions = root.find('permissions')
         if permissions is None or len(permissions) == 0:
@@ -98,6 +104,7 @@ class UserTagsObjectTypeMixin:
         EntityUserTags, description='Tags connected to the entity by the user'
     )
 
+    @staticmethod
     def resolve_user_tags(root, _info):
         return root.find('user_tags')
 
@@ -113,9 +120,11 @@ class AccessObjectTypeMixin:
         ' modified'
     )
 
+    @staticmethod
     def resolve_writable(root, _info):
         return get_boolean_from_element(root, 'writable')
 
+    @staticmethod
     def resolve_in_use(root, _info):
         return get_boolean_from_element(root, 'in_use')
 

--- a/selene/schema/filters/fields.py
+++ b/selene/schema/filters/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.base import BaseObjectType
@@ -49,6 +47,7 @@ class FilterDelta(graphene.ObjectType):
     new = graphene.Boolean()
     same = graphene.Boolean()
 
+    @staticmethod
     def resolve_states(root, _info):
         return get_text(root)
 
@@ -58,12 +57,15 @@ class Filter(EntityObjectType):
     term = graphene.String()
     alerts = graphene.List(FilterAlerts)
 
+    @staticmethod
     def resolve_entity_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_term(root, _info):
         return get_text_from_element(root, 'term')
 
+    @staticmethod
     def resolve_alerts(root, _info):
         alerts = root.find('alerts')
         if alerts is not None:

--- a/selene/schema/filters/mutations.py
+++ b/selene/schema/filters/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from gvm.protocols.next import (
@@ -56,8 +54,9 @@ class CloneFilter(graphene.Mutation):
 
     filter_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, copy_id):
+    def mutate(_root, info, copy_id):
         gmp = get_gmp(info)
         resp = gmp.clone_filter(str(copy_id))
         return CloneFilter(filter_id=resp.get('id'))
@@ -89,8 +88,9 @@ class CreateFilter(graphene.Mutation):
 
     filter_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_filter(
@@ -121,8 +121,9 @@ class DeleteFilter(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, filter_id, ultimate):
+    def mutate(_root, info, filter_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_filter(filter_id=str(filter_id), ultimate=ultimate)
         return DeleteFilter(ok=True)
@@ -260,8 +261,9 @@ class ModifyFilter(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         filter_id = str(input_object.filter_id)
 

--- a/selene/schema/filters/queries.py
+++ b/selene/schema/filters/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/hosts/fields.py
+++ b/selene/schema/hosts/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.base import BaseObjectType
@@ -49,21 +47,27 @@ class HostResultCount(graphene.ObjectType):
         description="Number of false positive results for the host"
     )
 
+    @staticmethod
     def resolve_current(parent, _info):
         return get_int_from_element(parent, 'page')
 
+    @staticmethod
     def resolve_high(parent, _info):
         return get_int_from_element(parent.find('hole'), 'page')
 
+    @staticmethod
     def resolve_medium(parent, _info):
         return get_int_from_element(parent.find('warning'), 'page')
 
+    @staticmethod
     def resolve_low(parent, _info):
         return get_int_from_element(parent.find('info'), 'page')
 
+    @staticmethod
     def resolve_log(parent, _info):
         return get_int_from_element(parent.find('log'), 'page')
 
+    @staticmethod
     def resolve_false_positive(parent, _info):
         return get_int_from_element(parent.find('false_positive'), 'page')
 
@@ -75,6 +79,7 @@ class HostResults(graphene.ObjectType):
 
     counts = graphene.Field(HostResultCount)
 
+    @staticmethod
     def resolve_counts(root, _info):
         return root
 
@@ -82,6 +87,7 @@ class HostResults(graphene.ObjectType):
 class HostPortCounts(graphene.ObjectType):
     current = graphene.Int(description="Current ports for the host")
 
+    @staticmethod
     def resolve_current(parent, _info):
         return get_int_from_element(parent, 'page')
 
@@ -93,6 +99,7 @@ class HostPorts(graphene.ObjectType):
 
     counts = graphene.Field(HostPortCounts)
 
+    @staticmethod
     def resolve_counts(root, _info):
         return root
 
@@ -103,15 +110,19 @@ class RouteHost(graphene.ObjectType):
     distance = graphene.Int()
     same_source = graphene.Boolean()
 
+    @staticmethod
     def resolve_host_id(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_ip(root, _info):
         return get_text_from_element(root, 'ip')
 
+    @staticmethod
     def resolve_distance(root, _info):
         return get_int_from_element(root, 'distance')
 
+    @staticmethod
     def resolve_same_source(root, _info):
         return get_boolean_from_element(root, 'same_source')
 
@@ -119,6 +130,7 @@ class RouteHost(graphene.ObjectType):
 class Route(graphene.ObjectType):
     hosts = graphene.List(RouteHost)
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = root.findall('host')
         if hosts is not None:
@@ -143,6 +155,7 @@ class HostDetail(graphene.ObjectType):
     source = graphene.Field(DetailSource)
     extra = graphene.String()
 
+    @staticmethod
     def resolve_source(root, _info):
         return root.find('source')
 
@@ -160,51 +173,61 @@ class HostIdentifier(BaseObjectType):
     os_id = graphene.String()
     os_title = graphene.String()
 
+    @staticmethod
     def resolve_value(root, _info):
         return get_text_from_element(root, 'value')
 
+    @staticmethod
     def resolve_creation_time(root, _info):
         return get_datetime_from_element(root, 'creation_time')
 
+    @staticmethod
     def resolve_modification_time(root, _info):
         return get_datetime_from_element(root, 'creation_time')
 
+    @staticmethod
     def resolve_source_id(root, _info):
         source = root.find('source')
         if source is not None:
             return parse_uuid(source.get('id'))
         return None
 
+    @staticmethod
     def resolve_source_name(root, _info):
         source = root.find('source')
         if source is not None:
             return get_text_from_element(source, 'name')
         return None
 
+    @staticmethod
     def resolve_source_type(root, _info):
         source = root.find('source')
         if source is not None:
             return get_text_from_element(source, 'type')
         return None
 
+    @staticmethod
     def resolve_source_data(root, _info):
         source = root.find('source')
         if source is not None:
             return get_text_from_element(source, 'data')
         return None
 
+    @staticmethod
     def resolve_source_deleted(root, _info):
         source = root.find('source')
         if source is not None:
             return get_boolean_from_element(source, 'deleted')
         return None
 
+    @staticmethod
     def resolve_os_id(root, _info):
         os = root.find('os')
         if os is not None:
             return parse_uuid(os.get('id'))
         return None
 
+    @staticmethod
     def resolve_os_title(root, _info):
         os = root.find('os')
         if os is not None:
@@ -220,22 +243,26 @@ class Host(EntityObjectType):
     details = graphene.List(HostDetail)
     routes = graphene.List(Route)
 
+    @staticmethod
     def resolve_identifiers(root, _info):
         identifiers = root.find('identifiers')
         if identifiers is not None:
             return identifiers.findall('identifier')
         return None
 
+    @staticmethod
     def resolve_severity(root, _info):
         severity = root.find('host').find('severity')
         return get_text_from_element(severity, 'value')
 
+    @staticmethod
     def resolve_routes(root, _info):
         routes = root.find('host').find('routes')
         if routes is not None:
             return routes.findall('route')
         return None
 
+    @staticmethod
     def resolve_details(root, _info):
         details = root.find('host').findall('detail')
         if details is not None:
@@ -255,24 +282,31 @@ class ReportHost(graphene.ObjectType):
 
     details = graphene.List(HostDetail)
 
+    @staticmethod
     def resolve_ip(root, _info):
         return get_text_from_element(root, 'ip')
 
+    @staticmethod
     def resolve_asset_id(root, _info):
         asset = root.find('asset')
         return asset.get('asset_id')
 
+    @staticmethod
     def resolve_start(root, _info):
         return get_datetime_from_element(root, 'start')
 
+    @staticmethod
     def resolve_end(root, _info):
         return get_datetime_from_element(root, 'end')
 
+    @staticmethod
     def resolve_details(root, _info):
         return root.findall('detail')
 
+    @staticmethod
     def resolve_ports(root, _info):
         return root.find('port_count')
 
+    @staticmethod
     def resolve_results(root, _info):
         return root.find('result_count')

--- a/selene/schema/hosts/mutations.py
+++ b/selene/schema/hosts/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from gvm.protocols.next import AssetType as GvmAssetType
@@ -55,8 +53,9 @@ class CreateHost(graphene.Mutation):
 
     host_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_host(input_object.name, comment=input_object.comment)
@@ -79,8 +78,9 @@ class DeleteHost(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, host_id):
+    def mutate(_root, info, host_id):
         gmp = get_gmp(info)
         gmp.delete_asset(asset_id=str(host_id))
         return DeleteHost(ok=True)
@@ -103,8 +103,9 @@ class DeleteHostsByReport(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, report_id):
+    def mutate(_root, info, report_id):
         gmp = get_gmp(info)
         gmp.delete_asset(report_id=str(report_id))
         return DeleteHostsByReport(ok=True)
@@ -240,8 +241,9 @@ class ModifyHost(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         host_id = str(input_object.host_id)
         comment = input_object.comment

--- a/selene/schema/hosts/queries.py
+++ b/selene/schema/hosts/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/notes/fields.py
+++ b/selene/schema/notes/fields.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
+import graphene
 
 from graphql import GraphQLError
-import graphene
 
 from selene.schema.severity import SeverityType
 
@@ -59,33 +58,42 @@ class Note(EntityObjectType):
     task = graphene.Field(Task)
     result = graphene.Field(NoteResult)
 
+    @staticmethod
     def resolve_name(root, _info):
         raise GraphQLError(
             f'Cannot query field "{_info.field_name}"'
             f' on type "{_info.parent_type}".'
         )
 
+    @staticmethod
     def resolve_end_time(root, _info):
         return get_datetime_from_element(root, 'end_time')
 
+    @staticmethod
     def resolve_active(root, _info):
         return get_boolean_from_element(root, 'active')
 
+    @staticmethod
     def resolve_orphan(root, _info):
         return get_boolean_from_element(root, 'orphan')
 
+    @staticmethod
     def resolve_text(root, _info):
         return get_text_from_element(root, 'text')
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = get_text_from_element(root, 'hosts')
         return csv_to_list(hosts)
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_text_from_element(root, 'port')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'severity')
 
+    @staticmethod
     def resolve_threat(root, _info):
         return get_text_from_element(root, 'threat')

--- a/selene/schema/notes/mutations.py
+++ b/selene/schema/notes/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.schema.utils import get_gmp, require_authentication
@@ -47,8 +45,9 @@ class CloneNote(graphene.Mutation):
 
     note_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, copy_id):
+    def mutate(_root, info, copy_id):
         gmp = get_gmp(info)
         resp = gmp.clone_note(str(copy_id))
         return CloneNote(note_id=resp.get('id'))
@@ -92,8 +91,9 @@ class CreateNote(graphene.Mutation):
 
     note_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         text = input_object.text
         nvt_oid = input_object.nvt_oid
         days_active = input_object.days_active
@@ -168,8 +168,9 @@ class ModifyNote(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         note_id = str(input_object.note_id)
         text = input_object.text
         days_active = input_object.days_active
@@ -224,8 +225,9 @@ class DeleteNote(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, note_id, ultimate):
+    def mutate(_root, info, note_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_note(str(note_id), ultimate=ultimate)
         return DeleteNote(ok=True)

--- a/selene/schema/notes/queries.py
+++ b/selene/schema/notes/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/nvts/fields.py
+++ b/selene/schema/nvts/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import (
@@ -113,9 +111,11 @@ class QoD(graphene.ObjectType):
     value = graphene.Int(description='The numeric QoD value.')
     qod_type = graphene.Field(QoDType, name="type", description='The QoD type.')
 
+    @staticmethod
     def resolve_value(root, _info):
         return get_int_from_element(root, 'value')
 
+    @staticmethod
     def resolve_qod_type(root, _info):
         return get_text_from_element(root, 'type')
 
@@ -131,18 +131,23 @@ class NvtSeverity(graphene.ObjectType):
         description='The CVSS Vector responsible for the Score.'
     )
 
+    @staticmethod
     def resolve_date(root, _info):
         return get_datetime_from_element(root, 'date')
 
+    @staticmethod
     def resolve_origin(root, _info):
         return get_text_from_element(root, 'origin')
 
+    @staticmethod
     def resolve_score(root, _info):
         return get_int_from_element(root, 'score')
 
+    @staticmethod
     def resolve_severity_type(root, _info):
         return root.get('type')
 
+    @staticmethod
     def resolve_vector(root, _info):
         return get_text_from_element(root, 'value')
 
@@ -160,9 +165,11 @@ class NvtReference(graphene.ObjectType):
         ),
     )
 
+    @staticmethod
     def resolve_reference_id(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_reference_type(root, _info):
         return root.get('type')
 
@@ -173,9 +180,11 @@ class NvtPreferenceNvt(graphene.ObjectType):
     oid = graphene.String(name='id')
     name = graphene.String()
 
+    @staticmethod
     def resolve_oid(root, _info):
         return root.get('oid')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -211,27 +220,35 @@ class NvtPreference(graphene.ObjectType):
         ),
     )
 
+    @staticmethod
     def resolve_hr_name(root, _info):
         return get_text_from_element(root, 'hr_name')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_preference_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_value(root, _info):
         return get_text_from_element(root, 'value')
 
+    @staticmethod
     def resolve_default(root, _info):
         return get_text_from_element(root, 'default')
 
+    @staticmethod
     def resolve_preference_id(root, _info):
         return get_int_from_element(root, 'id')
 
+    @staticmethod
     def resolve_nvt(root, _info):
         return root.find('nvt')
 
+    @staticmethod
     def resolve_alternative_values(root, _info):
         alts = root.findall('alt')
         if alts is not None and len(alts) > 0:
@@ -246,12 +263,15 @@ class NvtSolution(graphene.ObjectType):
     solution_method = graphene.String(name='method')
     solution_text = graphene.String(name='description')
 
+    @staticmethod
     def resolve_solution_type(root, _info):
         return root.get('type')
 
+    @staticmethod
     def resolve_solution_method(root, _info):
         return root.get('method')
 
+    @staticmethod
     def resolve_solution_text(root, _info):
         return root.text
 
@@ -282,9 +302,11 @@ class BaseNvtFamily(graphene.ObjectType):
     name = graphene.String()
     max_nvt_count = graphene.Int()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_max_nvt_count(root, _info):
         return get_int_from_element(root, 'max_nvt_count')
 
@@ -340,39 +362,49 @@ class ScanConfigNVT(graphene.ObjectType):
         NvtSolution, description='Fix solution for this NVT'
     )
 
+    @staticmethod
     def resolve_oid(root, _info):
         return root.get('oid')
 
+    @staticmethod
     def resolve_category(root, _info):
         return get_int_from_element(root, 'category')
 
+    @staticmethod
     def resolve_preference_count(root, _info):
         return get_int_from_element(root, 'preference_count')
 
+    @staticmethod
     def resolve_timeout(root, _info):
         return get_int_from_element(root, 'timeout')
 
+    @staticmethod
     def resolve_default_timeout(root, _info):
         return get_int_from_element(root, 'default_timeout')
 
+    @staticmethod
     def resolve_qod(root, _info):
         return root.find('qod')
 
+    @staticmethod
     def resolve_score(root, _info):
         severities = root.find('severities')
         if severities is not None:
             return severities.get('score')
 
+    @staticmethod
     def resolve_severities(root, _info):
         severities = root.find('severities')
         if severities is not None:
             return severities.findall('severity')
 
+    @staticmethod
     def resolve_reference_warning(root, _info):
         refs = root.find('refs')
         if refs is not None:
             return get_text_from_element(refs, 'warning')
 
+    @staticmethod
     def resolve_other_references(root, _info):
         refs = root.find('refs')
         if refs is not None:
@@ -380,6 +412,7 @@ class ScanConfigNVT(graphene.ObjectType):
                 ref for ref in refs.findall('ref') if ref.get('type') == 'url'
             ]
 
+    @staticmethod
     def resolve_cert_references(root, _info):
         refs = root.find('refs')
         if refs is not None:
@@ -392,6 +425,7 @@ class ScanConfigNVT(graphene.ObjectType):
                 )
             ]
 
+    @staticmethod
     def resolve_bid_references(root, _info):
         refs = root.find('refs')
         if refs is not None:
@@ -401,6 +435,7 @@ class ScanConfigNVT(graphene.ObjectType):
                 if (ref.get('type') == 'bid' or ref.get('type') == 'bugtraq_id')
             ]
 
+    @staticmethod
     def resolve_cve_references(root, _info):
         refs = root.find('refs')
         if refs is not None:
@@ -410,14 +445,17 @@ class ScanConfigNVT(graphene.ObjectType):
                 if (ref.get('type') == 'cve' or ref.get('type') == 'cve_id')
             ]
 
+    @staticmethod
     def resolve_tags(root, _info):
         return root.find('tags')
 
+    @staticmethod
     def resolve_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is not None:
             return preferences.findall('preference')
 
+    @staticmethod
     def resolve_solution(root, _info):
         return root.find('solution')
 
@@ -469,65 +507,78 @@ class NVT(EntityObjectType):
         NvtSolution, description='Fix solution for this NVT'
     )
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_update_time(root, _info):
         return get_datetime_from_element(root, 'update_time')
 
+    @staticmethod
     def resolve_family(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_text_from_element(nvt, 'family')
         return None
 
+    @staticmethod
     def resolve_cvss_base(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_text_from_element(nvt, 'cvss_base')
         return None
 
+    @staticmethod
     def resolve_score(root, _info):
         severities = root.find('nvt/severities')
         if severities is not None:
             return severities.get('score')
 
+    @staticmethod
     def resolve_tags(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return nvt.find('tags')
         return None
 
+    @staticmethod
     def resolve_category(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_int_from_element(nvt, 'category')
 
+    @staticmethod
     def resolve_preference_count(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_int_from_element(nvt, 'preference_count')
 
+    @staticmethod
     def resolve_timeout(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_int_from_element(nvt, 'timeout')
 
+    @staticmethod
     def resolve_default_timeout(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return get_int_from_element(nvt, 'default_timeout')
 
+    @staticmethod
     def resolve_qod(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:
             return nvt.find('qod')
 
+    @staticmethod
     def resolve_severities(root, _info):
         severities = root.find('nvt/severities')
         if severities is not None:
             return severities.findall('severity')
 
+    @staticmethod
     def resolve_other_references(root, _info):
         refs = root.find('nvt/refs')
         if refs is not None:
@@ -535,6 +586,7 @@ class NVT(EntityObjectType):
                 ref for ref in refs.findall('ref') if ref.get('type') == 'url'
             ]
 
+    @staticmethod
     def resolve_cert_references(root, _info):
         refs = root.find('nvt/refs')
         if refs is not None:
@@ -547,6 +599,7 @@ class NVT(EntityObjectType):
                 )
             ]
 
+    @staticmethod
     def resolve_bid_references(root, _info):
         refs = root.find('nvt/refs')
         if refs is not None:
@@ -556,6 +609,7 @@ class NVT(EntityObjectType):
                 if (ref.get('type') == 'bid' or ref.get('type') == 'bugtraq_id')
             ]
 
+    @staticmethod
     def resolve_cve_references(root, _info):
         refs = root.find('nvt/refs')
         if refs is not None:
@@ -565,16 +619,19 @@ class NVT(EntityObjectType):
                 if (ref.get('type') == 'cve' or ref.get('type') == 'cve_id')
             ]
 
+    @staticmethod
     def resolve_reference_warning(root, _info):
         refs = root.find('nvt/refs')
         if refs is not None:
             return get_text_from_element(refs, 'warning')
 
+    @staticmethod
     def resolve_preferences(root, _info):
         preferences = root.find('nvt/preferences')
         if preferences is not None:
             return preferences.findall('preference')
 
+    @staticmethod
     def resolve_solution(root, _info):
         nvt = root.find('nvt')
         if nvt is not None:

--- a/selene/schema/nvts/mutations.py
+++ b/selene/schema/nvts/mutations.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
+
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,
     create_export_by_filter_mutation,

--- a/selene/schema/nvts/queries.py
+++ b/selene/schema/nvts/queries.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from graphql import ResolveInfo
+
 from gvm.protocols.next import InfoType as GvmInfoType
 
 from selene.schema.nvts.fields import (

--- a/selene/schema/operating_systems/fields.py
+++ b/selene/schema/operating_systems/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.base import BaseObjectType
@@ -30,6 +28,7 @@ from selene.schema.entity import EntityObjectType
 class OperatingSystemHost(BaseObjectType):
     severity = graphene.Field(SeverityType)
 
+    @staticmethod
     def resolve_severity(root, _info):
         severity = root.find('severity')
         return get_text_from_element(severity, 'value')
@@ -45,30 +44,37 @@ class OperatingSystemInformation(graphene.ObjectType):
     host_count = graphene.Int()
     hosts = graphene.List(OperatingSystemHost)
 
+    @staticmethod
     def resolve_latest_severity(root, _info):
         severity = root.find('latest_severity')
         return get_text_from_element(severity, 'value')
 
+    @staticmethod
     def resolve_highest_severity(root, _info):
         severity = root.find('highest_severity')
         return get_text_from_element(severity, 'value')
 
+    @staticmethod
     def resolve_average_severity(root, _info):
         severity = root.find('average_severity')
         return get_text_from_element(severity, 'value')
 
+    @staticmethod
     def resolve_title(root, _info):
         source = root.find('source')
         if source is not None:
             return parse_uuid(source.get('id'))
         return None
 
+    @staticmethod
     def resolve_installs(root, _info):
         return get_int_from_element(root, 'installs')
 
+    @staticmethod
     def resolve_host_count(root, _info):
         return get_int_from_element(root, 'hosts')
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = root.find('hosts').findall('asset')
         if hosts is not None:
@@ -81,5 +87,6 @@ class OperatingSystem(EntityObjectType):
 
     operating_system_information = graphene.Field(OperatingSystemInformation)
 
+    @staticmethod
     def resolve_operating_system_information(root, _info):
         return root.find('os')

--- a/selene/schema/operating_systems/mutations.py
+++ b/selene/schema/operating_systems/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import AssetType as GvmAssetType
@@ -46,8 +44,9 @@ class DeleteOperatingSystem(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, operating_system_id):
+    def mutate(_root, info, operating_system_id):
         gmp = get_gmp(info)
         gmp.delete_asset(asset_id=str(operating_system_id))
         return DeleteOperatingSystem(ok=True)
@@ -70,8 +69,9 @@ class DeleteOperatingSystemsByReport(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, report_id):
+    def mutate(_root, info, report_id):
         gmp = get_gmp(info)
         gmp.delete_asset(report_id=str(report_id))
         return DeleteOperatingSystemsByReport(ok=True)
@@ -209,8 +209,9 @@ class ModifyOperatingSystem(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         operating_system_id = str(input_object.operating_system_id)
         comment = input_object.comment

--- a/selene/schema/operating_systems/queries.py
+++ b/selene/schema/operating_systems/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/oval_definitions/fields.py
+++ b/selene/schema/oval_definitions/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member, not-an-iterable
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -35,9 +33,11 @@ class HistoryStatusChange(graphene.ObjectType):
     status = graphene.String()
     date = graphene.String()
 
+    @staticmethod
     def resolve_status(root, _info):
         return get_text(root)
 
+    @staticmethod
     def resolve_date(root, _info):
         return parse_datetime(root.get('date'))
 
@@ -49,26 +49,31 @@ class OvalDefinitionHistory(graphene.ObjectType):
     organization = graphene.String()
     status_changes = graphene.List(HistoryStatusChange)
 
+    @staticmethod
     def resolve_status(root, _info):
         return get_text_from_element(root, '{*}status')
 
+    @staticmethod
     def resolve_date(root, _info):
         submitted = root.find('{*}dates/{*}submitted')
         if submitted is not None:
             return parse_datetime(submitted.get('date'))
         return None
 
+    @staticmethod
     def resolve_contributor(root, _info):
         submitted = root.find('{*}dates/{*}submitted')
         if submitted is not None:
             return get_text_from_element(submitted, '{*}contributor')
 
+    @staticmethod
     def resolve_organization(root, _info):
         contributor = root.find('{*}dates/{*}submitted/{*}contributor')
         if contributor is not None:
             return contributor.get('organization')
         return None
 
+    @staticmethod
     def resolve_status_changes(root, _info):
         dates = root.find('{*}dates')
         if dates is not None:
@@ -87,24 +92,29 @@ class OvalDefinitionCriteria(graphene.ObjectType):
     criterion = graphene.String()
     criteria = graphene.List(lambda: OvalDefinitionCriteria)
 
+    @staticmethod
     def resolve_operator(root, _info):
         return root.get('operator')
 
+    @staticmethod
     def resolve_comment(root, _info):
         return root.get('comment')
 
+    @staticmethod
     def resolve_extend_definition(root, _info):
         extend_definition = root.find('{*}extend_definition')
         if extend_definition is not None:
             return extend_definition.get('comment')
         return None
 
+    @staticmethod
     def resolve_criterion(root, _info):
         criterion = root.find('{*}criterion')
         if criterion is not None:
             return criterion.get('comment')
         return None
 
+    @staticmethod
     def resolve_criteria(root, _info):
         criteria = root.findall('{*}criteria')
         if len(criteria) != 0:
@@ -117,12 +127,15 @@ class OvalDefinitionRefs(graphene.ObjectType):
     ref_id = graphene.String(name='id', description='ID of this reference')
     url = graphene.String(description='URL of this reference')
 
+    @staticmethod
     def resolve_source(root, _info):
         return root.get('source')
 
+    @staticmethod
     def resolve_ref_id(root, _info):
         return root.get('ref_id')
 
+    @staticmethod
     def resolve_url(root, _info):
         return root.get('ref_url')
 
@@ -132,15 +145,18 @@ class OvalDefinitionAffectedFamily(graphene.ObjectType):
     platforms = graphene.List(graphene.String)
     products = graphene.List(graphene.String)
 
+    @staticmethod
     def resolve_family(root, _info):
         return root.get('family')
 
+    @staticmethod
     def resolve_platforms(root, _info):
         platforms = root.findall('{*}platform')
         if len(platforms) != 0:
             return [platform.text for platform in platforms]
         return None
 
+    @staticmethod
     def resolve_products(root, _info):
         products = root.findall('{*}product')
         if len(products) != 0:
@@ -165,39 +181,46 @@ class OvalDefinition(EntityObjectType):
     title = graphene.String()
     version = graphene.Int()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_cve_refs(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_int_from_element(ovaldef, 'cve_refs')
         return None
 
+    @staticmethod
     def resolve_deprecated(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_boolean_from_element(ovaldef, 'deprecated')
         return None
 
+    @staticmethod
     def resolve_description(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'description')
         return None
 
+    @staticmethod
     def resolve_file_path(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'file')
         return None
 
+    @staticmethod
     def resolve_info_class(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'class')
         return None
 
+    @staticmethod
     def resolve_affected_family(root, _info):
         affected = root.find(
             'ovaldef/raw_data/{*}definition/{*}metadata/{*}affected'
@@ -206,6 +229,7 @@ class OvalDefinition(EntityObjectType):
             return affected
         return None
 
+    @staticmethod
     def resolve_history(root, _info):
         history = root.find(
             'ovaldef/raw_data/{*}definition/{*}metadata/{*}oval_repository'
@@ -214,12 +238,14 @@ class OvalDefinition(EntityObjectType):
             return history
         return None
 
+    @staticmethod
     def resolve_criteria(root, _info):
         criteria = root.find('ovaldef/raw_data/{*}definition/{*}criteria')
         if criteria is not None:
             return criteria
         return None
 
+    @staticmethod
     def resolve_references(root, _info):
         metadata = root.find('ovaldef/raw_data/{*}definition/{*}metadata')
         if metadata is not None:
@@ -228,24 +254,28 @@ class OvalDefinition(EntityObjectType):
                 return references
         return None
 
+    @staticmethod
     def resolve_score(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'score')
         return None
 
+    @staticmethod
     def resolve_status(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'status')
         return None
 
+    @staticmethod
     def resolve_title(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:
             return get_text_from_element(ovaldef, 'title')
         return None
 
+    @staticmethod
     def resolve_version(root, _info):
         ovaldef = root.find('ovaldef')
         if ovaldef is not None:

--- a/selene/schema/oval_definitions/mutations.py
+++ b/selene/schema/oval_definitions/mutations.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from gvm.protocols.next import InfoType as GvmInfoType
+
 from selene.schema.entities import (
     create_export_secinfos_by_ids_mutation,
     create_export_by_filter_mutation,

--- a/selene/schema/oval_definitions/queries.py
+++ b/selene/schema/oval_definitions/queries.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from graphql import ResolveInfo
+
 from gvm.protocols.next import InfoType as GvmInfoType
 
 from selene.schema.oval_definitions.fields import OvalDefinition

--- a/selene/schema/overrides/fields.py
+++ b/selene/schema/overrides/fields.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
+import graphene
 
 from graphql import GraphQLError
-import graphene
 
 from selene.schema.severity import SeverityType
 
@@ -63,33 +62,42 @@ class Override(EntityObjectType):
     task = graphene.Field(Task)
     result = graphene.Field(Result)
 
+    @staticmethod
     def resolve_name(root, _info):
         raise GraphQLError(
             f'Cannot query field "{_info.field_name}"'
             f' on type "{_info.parent_type}".'
         )
 
+    @staticmethod
     def resolve_end_time(root, _info):
         return get_datetime_from_element(root, 'end_time')
 
+    @staticmethod
     def resolve_active(root, _info):
         return get_boolean_from_element(root, 'active')
 
+    @staticmethod
     def resolve_orphan(root, _info):
         return get_boolean_from_element(root, 'orphan')
 
+    @staticmethod
     def resolve_text(root, _info):
         return get_text_from_element(root, 'text')
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = get_text_from_element(root, 'hosts')
         return csv_to_list(hosts)
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_text_from_element(root, 'port')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'severity')
 
+    @staticmethod
     def resolve_new_severity(root, _info):
         return get_text_from_element(root, 'new_severity')

--- a/selene/schema/overrides/mutations.py
+++ b/selene/schema/overrides/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.schema.utils import get_gmp, require_authentication
@@ -51,8 +49,9 @@ class CloneOverride(graphene.Mutation):
 
     override_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, copy_id):
+    def mutate(_root, info, copy_id):
         gmp = get_gmp(info)
         resp = gmp.clone_override(str(copy_id))
         return CloneOverride(override_id=resp.get('id'))
@@ -112,8 +111,9 @@ class CreateOverride(graphene.Mutation):
 
     override_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         text = input_object.text
         nvt_oid = input_object.nvt_oid
         days_active = input_object.days_active
@@ -197,8 +197,9 @@ class ModifyOverride(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         override_id = str(input_object.override_id)
         text = input_object.text
         days_active = input_object.days_active
@@ -255,8 +256,9 @@ class DeleteOverride(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, override_id, ultimate):
+    def mutate(_root, info, override_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_override(str(override_id), ultimate=ultimate)
         return DeleteOverride(ok=True)

--- a/selene/schema/overrides/queries.py
+++ b/selene/schema/overrides/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/permissions/fields.py
+++ b/selene/schema/permissions/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -51,15 +49,19 @@ class PermissionSubject(graphene.ObjectType):
     subject_type = graphene.String(name='type')
     trash = graphene.Boolean()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_subject_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_boolean_from_element(root, 'trash')
 
@@ -74,21 +76,27 @@ class PermissionResource(graphene.ObjectType):
     deleted = graphene.Boolean()
     permissions = graphene.List(EntityPermission)
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_permission_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_boolean_from_element(root, 'trash')
 
+    @staticmethod
     def resolve_deleted(root, _info):
         return get_boolean_from_element(root, 'deleted')
 
+    @staticmethod
     def resolve_permissions(root, _info):
         permissions = root.find('permissions')
         if permissions is None or permissions and len(permissions) == 0:
@@ -100,8 +108,10 @@ class Permission(EntityObjectType):
     resource = graphene.Field(PermissionResource)
     subject = graphene.Field(PermissionSubject)
 
+    @staticmethod
     def resolve_resource(root, _info):
         return root.find('resource')
 
+    @staticmethod
     def resolve_subject(root, _info):
         return root.find('subject')

--- a/selene/schema/permissions/mutations.py
+++ b/selene/schema/permissions/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.permissions.fields import (
@@ -71,8 +69,9 @@ class ClonePermission(graphene.Mutation):
 
     permission_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, permission_id):
+    def mutate(_root, info, permission_id):
         gmp = get_gmp(info)
         elem = gmp.clone_permission(str(permission_id))
         return ClonePermission(permission_id=elem.get('id'))
@@ -154,8 +153,9 @@ class CreatePermission(graphene.Mutation):
 
     id_of_created_permission = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         # Required args
@@ -248,8 +248,9 @@ class ModifyPermission(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         permission_id = (
             str(input_object.permission_id)

--- a/selene/schema/policies/fields.py
+++ b/selene/schema/policies/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import (
@@ -40,15 +38,19 @@ class PolicyFamily(graphene.ObjectType):
     max_nvt_count = graphene.Int()
     growing = graphene.Boolean()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_nvt_count(root, _info):
         return get_int_from_element(root, 'nvt_count')
 
+    @staticmethod
     def resolve_max_nvt_count(root, _info):
         return get_int_from_element(root, 'max_nvt_count')
 
+    @staticmethod
     def resolve_growing(root, _info):
         return get_boolean_from_element(root, 'growing')
 
@@ -59,9 +61,11 @@ class PolicyAudit(graphene.ObjectType):
     audit_id = graphene.String(name='id')
     name = graphene.String()
 
+    @staticmethod
     def resolve_audit_id(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -74,15 +78,19 @@ class PolicyNvtSelector(graphene.ObjectType):
     selector_type = graphene.Int(name='type')
     family_or_nvt = graphene.String()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_include(root, _info):
         return get_boolean_from_element(root, 'include')
 
+    @staticmethod
     def resolve_selector_type(root, _info):
         return get_int_from_element(root, 'type')
 
+    @staticmethod
     def resolve_family_or_nvt(root, _info):
         return get_text_from_element(root, 'family_or_nvt')
 
@@ -117,44 +125,56 @@ class Policy(EntityObjectType):
     )
     nvt_selectors = graphene.List(PolicyNvtSelector)
 
+    @staticmethod
     def resolve_policy_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_int_from_element(root, 'trash')
 
+    @staticmethod
     def resolve_family_count(root, _info):
         return get_int_from_element(root, 'family_count')
 
+    @staticmethod
     def resolve_family_growing(root, _info):
         family_count = root.find('family_count')
         return get_int_from_element(family_count, 'growing')
 
+    @staticmethod
     def resolve_nvt_count(root, _info):
         return get_int_from_element(root, 'nvt_count')
 
+    @staticmethod
     def resolve_nvt_growing(root, _info):
         nvt_count = root.find('nvt_count')
         return get_int_from_element(nvt_count, 'growing')
 
+    @staticmethod
     def resolve_usage_type(root, _info):
         return get_text_from_element(root, 'usage_type')
 
+    @staticmethod
     def resolve_max_nvt_count(root, _info):
         return get_int_from_element(root, 'max_nvt_count')
 
+    @staticmethod
     def resolve_known_nvt_count(root, _info):
         return get_int_from_element(root, 'known_nvt_count')
 
+    @staticmethod
     def resolve_predefined(root, _info):
         return get_boolean_from_element(root, 'predefined')
 
+    @staticmethod
     def resolve_families(root, _info):
         families = root.find('families')
         if families is None:
             return None
         return families.findall('family')
 
+    @staticmethod
     def resolve_nvt_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is not None:
@@ -168,6 +188,7 @@ class Policy(EntityObjectType):
                 ]
         return None
 
+    @staticmethod
     def resolve_scanner_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is not None:
@@ -180,12 +201,14 @@ class Policy(EntityObjectType):
                 ]
         return None
 
+    @staticmethod
     def resolve_audits(root, _info):
         audits = root.find('tasks')
         if audits is None:
             return None
         return audits.findall('task')
 
+    @staticmethod
     def resolve_nvt_selectors(root, _info):
         selectors = root.find('nvt_selectors')
         if selectors is None:

--- a/selene/schema/policies/mutations.py
+++ b/selene/schema/policies/mutations.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
-
 import graphene
 
 from selene.schema.utils import require_authentication, get_gmp
@@ -68,8 +65,9 @@ class DeletePolicy(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, policy_id, ultimate):
+    def mutate(_root, info, policy_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_policy(str(policy_id), ultimate=ultimate)
         return DeletePolicy(ok=True)
@@ -192,8 +190,9 @@ class ClonePolicy(graphene.Mutation):
 
     policy_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, policy_id):
+    def mutate(_root, info, policy_id):
         gmp = get_gmp(info)
         elem = gmp.clone_policy(str(policy_id))
         return ClonePolicy(policy_id=elem.get('id'))
@@ -258,8 +257,9 @@ class ImportPolicy(graphene.Mutation):
 
     policy_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, policy):
+    def mutate(_root, info, policy):
         gmp = get_gmp(info)
         elem = gmp.import_config(config=policy)
 
@@ -319,8 +319,9 @@ class CreatePolicy(graphene.Mutation):
 
     id_of_created_policy = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
         policy_id = (
             str(input_object.policy_id)
@@ -389,8 +390,9 @@ class ModifyPolicySetName(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None
@@ -454,8 +456,9 @@ class ModifyPolicySetComment(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None
@@ -535,8 +538,9 @@ class ModifyPolicySetFamilySelection(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None
@@ -640,8 +644,9 @@ class ModifyPolicySetNvtPreference(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None
@@ -727,8 +732,9 @@ class ModifyPolicySetNvtSelection(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None
@@ -812,8 +818,9 @@ class ModifyPolicySetScannerPreference(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         policy_id = (
             str(input_object.policy_id)
             if input_object.policy_id is not None

--- a/selene/schema/policies/queries.py
+++ b/selene/schema/policies/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/port_list/fields.py
+++ b/selene/schema/port_list/fields.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
+
 from gvm.protocols.next import PortRangeType as GvmPortRangeType
 
 from selene.schema.base import BaseObjectType
@@ -48,15 +47,19 @@ class PortRange(graphene.ObjectType):
         PortRangeType, name='type', description='Type of the port range'
     )
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_start(root, _info):
         return get_int_from_element(root, 'start')
 
+    @staticmethod
     def resolve_end(root, _info):
         return get_int_from_element(root, 'end')
 
+    @staticmethod
     def resolve_port_range_type(root, _info):
         type_string: str = get_text_from_element(root, 'type')
         if not type_string:
@@ -74,12 +77,15 @@ class PortCount(graphene.ObjectType):
     tcp = graphene.Int(description='Number of TCP ports')
     udp = graphene.Int(description='Number of UDP ports')
 
+    @staticmethod
     def resolve_count_all(root, _info):
         return get_int_from_element(root, 'all')
 
+    @staticmethod
     def resolve_tcp(root, _info):
         return get_int_from_element(root, 'tcp')
 
+    @staticmethod
     def resolve_udp(root, _info):
         return get_int_from_element(root, 'udp')
 
@@ -102,12 +108,14 @@ class PortList(EntityObjectType):
         PortListTarget, description="Targets using this port list"
     )
 
+    @staticmethod
     def resolve_port_ranges(root, _info):
         port_ranges = root.find('port_ranges')
         if port_ranges is None or len(port_ranges) == 0:
             return None
         return port_ranges.findall('port_range')
 
+    @staticmethod
     def resolve_targets(root, _info):
         targets = root.find('targets')
         if len(targets) == 0:

--- a/selene/schema/port_list/mutations.py
+++ b/selene/schema/port_list/mutations.py
@@ -16,10 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
-
 
 from selene.schema.entities import (
     create_delete_by_ids_mutation,
@@ -66,8 +63,9 @@ class CreatePortRange(graphene.Mutation):
         name='id', description="ID of the created port range"
     )
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_port_range(
@@ -88,8 +86,9 @@ class DeletePortRange(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, port_range_id):
+    def mutate(_root, info, port_range_id):
         gmp = get_gmp(info)
         gmp.delete_port_range(str(port_range_id))
         return DeletePortRange(ok=True)
@@ -132,8 +131,9 @@ class ClonePortList(graphene.Mutation):
         name='id', description="ID of the new port list"
     )
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, port_list_id):
+    def mutate(_root, info, port_list_id):
         gmp = get_gmp(info)
         elem = gmp.clone_port_list(str(port_list_id))
         return ClonePortList(port_list_id=elem.get('id'))
@@ -166,8 +166,9 @@ class CreatePortList(graphene.Mutation):
         name='id', description="ID of the new port list"
     )
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         comment = input_object.comment
@@ -203,8 +204,9 @@ class ModifyPortList(graphene.Mutation):
 
     ok = graphene.Boolean(description="True if no error occurred")
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         comment = input_object.comment

--- a/selene/schema/port_list/queries.py
+++ b/selene/schema/port_list/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/report_formats/fields.py
+++ b/selene/schema/report_formats/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.entity import EntityObjectType
@@ -43,24 +41,31 @@ class ReportFormat(EntityObjectType):
     active = graphene.Boolean()
     extension = graphene.String()
 
+    @staticmethod
     def resolve_summary(root, _info):
         return get_text_from_element(root, 'summary')
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'description')
 
+    @staticmethod
     def resolve_trust(root, _info):
         return get_text_from_element(root, 'trust')
 
+    @staticmethod
     def resolve_trust_time(root, _info):
         trust = root.find('trust')
         return get_datetime_from_element(trust, 'time')
 
+    @staticmethod
     def resolve_predefined(root, _info):
         return get_boolean_from_element(root, 'predefined')
 
+    @staticmethod
     def resolve_active(root, _info):
         return get_boolean_from_element(root, 'active')
 
+    @staticmethod
     def resolve_extension(root, _info):
         return get_text_from_element(root, 'extension')

--- a/selene/schema/report_formats/mutations.py
+++ b/selene/schema/report_formats/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import get_gmp, require_authentication
@@ -43,8 +41,9 @@ class DeleteReportFormat(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, report_format_id):
+    def mutate(_root, info, report_format_id):
         gmp = get_gmp(info)
         gmp.delete_report_format(str(report_format_id))
         return DeleteReportFormat(ok=True)
@@ -67,8 +66,9 @@ class ImportReportFormat(graphene.Mutation):
 
     report_format_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, report_format: str):
+    def mutate(_root, info, report_format: str):
         gmp = get_gmp(info)
 
         resp = gmp.import_report_format(report_format=report_format)
@@ -105,8 +105,9 @@ class ModifyReportFormat(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         gmp.modify_report_format(

--- a/selene/schema/reports/fields.py
+++ b/selene/schema/reports/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.resolver import text_resolver, int_resolver
@@ -49,9 +47,11 @@ class CountType(graphene.ObjectType):
     filtered = graphene.Int()
     current = graphene.Int()
 
+    @staticmethod
     def resolve_total(root, _info):
         return get_int_from_element(root, 'full')
 
+    @staticmethod
     def resolve_current(root, _info):
         _current = get_int_from_element(root, 'count')
         if _current is None:
@@ -66,6 +66,7 @@ class ReportSeverity(graphene.ObjectType):
     total = SeverityType()
     filtered = SeverityType()
 
+    @staticmethod
     def resolve_total(root, _info):
         return get_text_from_element(root, 'full')
 
@@ -80,18 +81,23 @@ class ReportResultCount(CountType):
     warning = graphene.Field(CountType)
     false_positive = graphene.Field(CountType)
 
+    @staticmethod
     def resolve_high(root, _info):
         return root.find('hole')
 
+    @staticmethod
     def resolve_info(root, _info):
         return root.find('info')
 
+    @staticmethod
     def resolve_log(root, _info):
         return root.find('log')
 
+    @staticmethod
     def resolve_warning(root, _info):
         return root.find('warning')
 
+    @staticmethod
     def resolve_false_positive(root, _info):
         return root.find('false_positive')
 
@@ -103,6 +109,7 @@ class ReportEntities(graphene.ObjectType):
 
     counts = graphene.Field(CountType)
 
+    @staticmethod
     def resolve_counts(root, _info):
         return root
 
@@ -118,6 +125,7 @@ class ReportPort(graphene.ObjectType):
     severity = SeverityType()
     threat = graphene.String()
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_text(root)
 
@@ -133,18 +141,23 @@ class DeltaReport(graphene.ObjectType):
     scan_start = graphene.DateTime()
     scan_end = graphene.DateTime()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_scan_run_status(root, _info):
         return get_text_from_element(root, 'scan_run_status')
 
+    @staticmethod
     def resolve_timestamp(root, _info):
         return get_datetime_from_element(root, 'timestamp')
 
+    @staticmethod
     def resolve_scan_start(root, _info):
         return get_datetime_from_element(root, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(root, _info):
         return get_datetime_from_element(root, 'scan_end')
 
@@ -155,9 +168,11 @@ class ErrorHost(graphene.ObjectType):
     name = graphene.String()
     asset_id = graphene.UUID(name="id")
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text(root)
 
+    @staticmethod
     def resolve_asset_id(root, _info):
         asset = root.find('asset')
         return parse_uuid(asset.get('asset_id'))
@@ -175,21 +190,27 @@ class Error(graphene.ObjectType):
     )
     severity = SeverityType()
 
+    @staticmethod
     def resolve_host(root, _info):
         return root.find('host')
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_text_from_element(root, 'port')
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'description')
 
+    @staticmethod
     def resolve_nvt(root, _info):
         return root.find('nvt')
 
+    @staticmethod
     def resolve_scan_nvt_version(root, _info):
         return get_datetime_from_element(root, 'scan_nvt_version')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'severity')
 
@@ -293,60 +314,74 @@ class Report(graphene.ObjectType):
     uuid = graphene.UUID(name='id')
     name = graphene.String()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.outer_report.get('id'))
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root.outer_report, 'name')
 
+    @staticmethod
     def resolve_owner(root, _info):
         return get_owner(root.outer_report)
 
+    @staticmethod
     def resolve_comment(root, _info):
         return get_text_from_element(root.outer_report, 'comment')
 
+    @staticmethod
     def resolve_creation_time(root, _info):
         return get_datetime_from_element(root.outer_report, 'creation_time')
 
+    @staticmethod
     def resolve_modification_time(root, _info):
         return get_datetime_from_element(root.outer_report, 'modification_time')
 
+    @staticmethod
     def resolve_writable(root, _info):
         return get_boolean_from_element(root.outer_report, 'writable')
 
+    @staticmethod
     def resolve_in_use(root, _info):
         return get_boolean_from_element(root.outer_report, 'in_use')
 
+    @staticmethod
     def resolve_user_tags(root, _info):
         user_tags = root.inner_report.find('user_tags')
         if user_tags is not None:
             return user_tags
         return None
 
+    @staticmethod
     def resolve_delta_report(root, _info):
         delta_report = root.inner_report.find('delta/report')
         if delta_report is not None:
             return delta_report
         return None
 
+    @staticmethod
     def resolve_report_format(root, _info):
         report_format = root.outer_report.find('report_format')
         if report_format is not None:
             return report_format
         return None
 
+    @staticmethod
     def resolve_closed_cves(root, _info):
         closed_cves = root.inner_report.find('closed_cves')
         if closed_cves is not None:
             return closed_cves
         return None
 
+    @staticmethod
     def resolve_task(root, _info):
         task = root.inner_report.find('task')
         if task is not None:
             return task
         return None
 
+    @staticmethod
     def resolve_permissions(root, _info):
         permissions = root.inner_report.find('permissions')
         if permissions is not None:
@@ -355,42 +390,55 @@ class Report(graphene.ObjectType):
                 return permissions
         return None
 
+    @staticmethod
     def resolve_scan_run_status(root, _info):
         return get_text_from_element(root.inner_report, 'scan_run_status')
 
+    @staticmethod
     def resolve_timezone(root, _info):
         return get_text_from_element(root.inner_report, 'timezone')
 
+    @staticmethod
     def resolve_timezone_abbreviation(root, _info):
         return get_text_from_element(root.inner_report, 'timezone_abbrev')
 
+    @staticmethod
     def resolve_timestamp(root, _info):
         return get_datetime_from_element(root.inner_report, 'timestamp')
 
+    @staticmethod
     def resolve_scan_start(root, _info):
         return get_datetime_from_element(root.inner_report, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(root, _info):
         return get_datetime_from_element(root.inner_report, 'scan_end')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return root.inner_report.find('severity')
 
+    @staticmethod
     def resolve_applications(root, _info):
         return root.inner_report.find('apps')
 
+    @staticmethod
     def resolve_tls_certificates(root, _info):
         return root.inner_report.find('ssl_certs')
 
+    @staticmethod
     def resolve_operating_systems(root, _info):
         return root.inner_report.find('os')
 
+    @staticmethod
     def resolve_vulnerabilities(root, _info):
         return root.inner_report.find('vulns')
 
+    @staticmethod
     def resolve_ports_count(root, _info):
         return root.inner_report.find('ports')
 
+    @staticmethod
     def resolve_ports(root, _info):
         ports = root.inner_report.find('ports')
         if ports is not None:
@@ -399,16 +447,19 @@ class Report(graphene.ObjectType):
                 return ports
         return None
 
+    @staticmethod
     def resolve_hosts_count(root, _info):
         hosts = root.inner_report.find('hosts')
         return hosts
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = root.inner_report.findall('host')
         if hosts is not None and len(hosts) > 0:
             return hosts
         return None
 
+    @staticmethod
     def resolve_results(root, _info):
         results = root.inner_report.find('results')
         if results is not None:
@@ -417,15 +468,18 @@ class Report(graphene.ObjectType):
                 return results
         return None
 
+    @staticmethod
     def resolve_results_count(root, _info):
         return root.inner_report.find('result_count')
 
+    @staticmethod
     def resolve_error_count(root, _info):
         errors = root.inner_report.find('errors')
         if errors is not None:
             return errors.find('count')
         return None
 
+    @staticmethod
     def resolve_errors(root, _info):
         errors = root.inner_report.find('errors')
         if errors is not None:

--- a/selene/schema/reports/mutations.py
+++ b/selene/schema/reports/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 import graphene
@@ -46,8 +44,9 @@ class DeleteReport(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, report_id):
+    def mutate(_root, info, report_id):
         gmp = get_gmp(info)
         gmp.delete_report(report_id)
         return DeleteReport(ok=True)
@@ -106,9 +105,10 @@ class ImportReport(graphene.Mutation):
 
     report_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
     def mutate(
-        root, info, report: str, task_id: str = UUID, in_assets: bool = None
+        _root, info, report: str, task_id: str = UUID, in_assets: bool = None
     ):
         gmp = get_gmp(info)
 

--- a/selene/schema/reports/queries.py
+++ b/selene/schema/reports/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/resolver.py
+++ b/selene/schema/resolver.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from selene.schema.utils import (
     get_text,
     get_text_from_element,

--- a/selene/schema/results/fields.py
+++ b/selene/schema/results/fields.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
+
 from lxml import etree
 
 from selene.schema.severity import SeverityType
@@ -62,6 +61,7 @@ class OriginResult(UUIDObjectTypeMixin, graphene.ObjectType):
 
     details = graphene.List(OriginResultDetail)
 
+    @staticmethod
     def resolve_details(root, _info):
         details = root.find('details')
         if details is None or len(details) == 0:
@@ -78,6 +78,7 @@ class ResultNVT(ScanConfigNVT):
 
     version = graphene.String(description='Version of the NVT used in the scan')
 
+    @staticmethod
     def resolve_version(root, _info):
         return get_text_from_element(root, 'version')
 
@@ -90,9 +91,11 @@ class ResultCVE(graphene.ObjectType):
         SeverityType, description='Severity of the CVE result.'
     )
 
+    @staticmethod
     def resolve_oid(root, _info):
         return root.get('oid')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'cvss_base')
 
@@ -130,13 +133,16 @@ class ResultHost(graphene.ObjectType):
         )
     )
 
+    @staticmethod
     def resolve_ip(root, _info):
         return get_text(root)
 
+    @staticmethod
     def resolve_asset_id(root, _info):
         asset = root.find('asset')
         return parse_uuid(asset.get('asset_id'))
 
+    @staticmethod
     def resolve_hostname(root, _info):
         return get_text_from_element(root, 'hostname')
 
@@ -168,18 +174,23 @@ class ResultOverride(
         description='Override end time in case of limit, else empty.'
     )
 
+    @staticmethod
     def resolve_active(root, _info):
         return get_boolean_from_element(root, 'active')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'severity')
 
+    @staticmethod
     def resolve_new_severity(root, _info):
         return get_text_from_element(root, 'new_severity')
 
+    @staticmethod
     def resolve_text(root, _info):
         return get_text_from_element(root, 'text')
 
+    @staticmethod
     def resolve_end_time(root, _info):
         return get_datetime_from_element(root, 'end_time')
 
@@ -243,50 +254,61 @@ class Result(  # changed mixin to remove comment mixin
         RemediationTicket, description='List of tickets on the result'
     )
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'description')
 
+    @staticmethod
     def resolve_origin_result(root, _info):
         detection = root.find('detection')
         if detection is None or len(detection) == 0:
             return None
         return detection.find('result')
 
+    @staticmethod
     def resolve_report_id(root, _info):
         report = root.find('report')
         if report is not None:
             return parse_uuid(root.find('report').get('id'))
 
+    @staticmethod
     def resolve_task(root, _info):
         return root.find('task')
 
+    @staticmethod
     def resolve_location(root, _info):
         return get_text_from_element(root, 'port')
 
+    @staticmethod
     def resolve_severity(root, _info):
         return get_text_from_element(root, 'severity')
 
+    @staticmethod
     def resolve_original_severity(root, _info):
         return get_text_from_element(root, 'original_severity')
 
+    @staticmethod
     def resolve_notes(root, _info):
         notes = root.find('notes')
         if notes is None or len(notes) == 0:
             return None
         return notes.findall('note')
 
+    @staticmethod
     def resolve_overrides(root, _info):
         overrides = root.find('overrides')
         if overrides is None or len(overrides) == 0:
             return None
         return overrides.findall('override')
 
+    @staticmethod
     def resolve_tickets(root, _info):
         tickets = root.find('tickets')
         if tickets is None or len(tickets) == 0:
             return None
         return tickets.findall('ticket')
 
+    @staticmethod
     def resolve_information(root, _info):
         result_info = root.find('nvt')
         info_type = get_text_from_element(result_info, 'type')
@@ -302,6 +324,7 @@ class Result(  # changed mixin to remove comment mixin
 
         return result_info
 
+    @staticmethod
     def resolve_result_type(root, _info):
         nvt = root.find('nvt')
 

--- a/selene/schema/results/mutations.py
+++ b/selene/schema/results/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from selene.schema.entities import (
     create_export_by_filter_mutation,
     create_export_by_ids_mutation,

--- a/selene/schema/results/queries.py
+++ b/selene/schema/results/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/roles/fields.py
+++ b/selene/schema/roles/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import string
 
 import graphene
@@ -34,6 +32,7 @@ class BaseRoleType(EntityObjectType):
 class Role(BaseRoleType):
     users = graphene.List(graphene.String)
 
+    @staticmethod
     def resolve_users(root, _info):
         user_string = get_text_from_element(root, 'users')
         if not user_string:

--- a/selene/schema/roles/mutations.py
+++ b/selene/schema/roles/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import require_authentication, get_gmp
@@ -66,8 +64,9 @@ class CloneRole(graphene.Mutation):
 
     role_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, role_id):
+    def mutate(_root, info, role_id):
         gmp = get_gmp(info)
         elem = gmp.clone_role(str(role_id))
         return CloneRole(role_id=elem.get('id'))
@@ -127,8 +126,9 @@ class CreateRole(graphene.Mutation):
 
     id_of_created_role = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         name = input_object.name if input_object.name is not None else None
@@ -174,8 +174,9 @@ class ModifyRole(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         role_id = (
             str(input_object.role_id)
             if input_object.role_id is not None
@@ -234,8 +235,9 @@ class DeleteRole(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, role_id, ultimate):
+    def mutate(_root, info, role_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_role(str(role_id), ultimate=ultimate)
         return DeleteRole(ok=True)

--- a/selene/schema/scan_configs/fields.py
+++ b/selene/schema/scan_configs/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import (
@@ -59,24 +57,31 @@ class ScannerPreference(graphene.ObjectType):
         ),
     )
 
+    @staticmethod
     def resolve_hr_name(root, _info):
         return get_text_from_element(root, 'hr_name')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_preference_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_value(root, _info):
         return get_text_from_element(root, 'value')
 
+    @staticmethod
     def resolve_default(root, _info):
         return get_text_from_element(root, 'default')
 
+    @staticmethod
     def resolve_preference_id(root, _info):
         return get_int_from_element(root, 'id')
 
+    @staticmethod
     def resolve_alternative_values(root, _info):
         alts = root.findall('alt')
         if alts is not None and len(alts) > 0:
@@ -92,15 +97,19 @@ class ScanConfigFamily(graphene.ObjectType):
     max_nvt_count = graphene.Int()
     growing = graphene.Boolean()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_nvt_count(root, _info):
         return get_int_from_element(root, 'nvt_count')
 
+    @staticmethod
     def resolve_max_nvt_count(root, _info):
         return get_int_from_element(root, 'max_nvt_count')
 
+    @staticmethod
     def resolve_growing(root, _info):
         return get_boolean_from_element(root, 'growing')
 
@@ -111,9 +120,11 @@ class ScanConfigTask(graphene.ObjectType):
     task_id = graphene.String(name='id')
     name = graphene.String()
 
+    @staticmethod
     def resolve_task_id(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -126,15 +137,19 @@ class ScanConfigNvtSelector(graphene.ObjectType):
     selector_type = graphene.Int(name='type')
     family_or_nvt = graphene.String()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_include(root, _info):
         return get_boolean_from_element(root, 'include')
 
+    @staticmethod
     def resolve_selector_type(root, _info):
         return get_int_from_element(root, 'type')
 
+    @staticmethod
     def resolve_family_or_nvt(root, _info):
         return get_text_from_element(root, 'family_or_nvt')
 
@@ -170,44 +185,56 @@ class ScanConfig(EntityObjectType):
     )
     nvt_selectors = graphene.List(ScanConfigNvtSelector)
 
+    @staticmethod
     def resolve_scan_config_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_int_from_element(root, 'trash')
 
+    @staticmethod
     def resolve_family_count(root, _info):
         return get_int_from_element(root, 'family_count')
 
+    @staticmethod
     def resolve_family_growing(root, _info):
         family_count = root.find('family_count')
         return get_int_from_element(family_count, 'growing')
 
+    @staticmethod
     def resolve_nvt_count(root, _info):
         return get_int_from_element(root, 'nvt_count')
 
+    @staticmethod
     def resolve_nvt_growing(root, _info):
         nvt_count = root.find('nvt_count')
         return get_int_from_element(nvt_count, 'growing')
 
+    @staticmethod
     def resolve_usage_type(root, _info):
         return get_text_from_element(root, 'usage_type')
 
+    @staticmethod
     def resolve_max_nvt_count(root, _info):
         return get_int_from_element(root, 'max_nvt_count')
 
+    @staticmethod
     def resolve_known_nvt_count(root, _info):
         return get_int_from_element(root, 'known_nvt_count')
 
+    @staticmethod
     def resolve_predefined(root, _info):
         return get_boolean_from_element(root, 'predefined')
 
+    @staticmethod
     def resolve_families(root, _info):
         families = root.find('families')
         if families is None:
             return None
         return families.findall('family')
 
+    @staticmethod
     def resolve_nvt_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is not None:
@@ -221,6 +248,7 @@ class ScanConfig(EntityObjectType):
                 ]
         return None
 
+    @staticmethod
     def resolve_scanner_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is not None:
@@ -233,12 +261,14 @@ class ScanConfig(EntityObjectType):
                 ]
         return None
 
+    @staticmethod
     def resolve_tasks(root, _info):
         tasks = root.find('tasks')
         if tasks is None:
             return None
         return tasks.findall('task')
 
+    @staticmethod
     def resolve_nvt_selectors(root, _info):
         selectors = root.find('nvt_selectors')
         if selectors is None:

--- a/selene/schema/scan_configs/mutations.py
+++ b/selene/schema/scan_configs/mutations.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
-
 import graphene
 
 from selene.schema.utils import require_authentication, get_gmp
@@ -66,8 +63,9 @@ class DeleteScanConfig(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, config_id, ultimate):
+    def mutate(_root, info, config_id, ultimate):
         gmp = get_gmp(info)
         gmp.delete_config(str(config_id), ultimate=ultimate)
         return DeleteScanConfig(ok=True)
@@ -186,8 +184,9 @@ class CloneScanConfig(graphene.Mutation):
 
     config_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, config_id):
+    def mutate(_root, info, config_id):
         gmp = get_gmp(info)
         elem = gmp.clone_config(str(config_id))
         return CloneScanConfig(config_id=elem.get('id'))
@@ -252,8 +251,9 @@ class ImportScanConfig(graphene.Mutation):
 
     config_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, config):
+    def mutate(_root, info, config):
         gmp = get_gmp(info)
         elem = gmp.import_config(config=config)
 
@@ -315,8 +315,9 @@ class CreateScanConfig(graphene.Mutation):
 
     id_of_created_config = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
         config_id = (
             str(input_object.config_id)
@@ -394,8 +395,9 @@ class CreateScanConfigFromOspScanner(graphene.Mutation):
 
     id_of_created_config = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
         scanner_id = (
             str(input_object.scanner_id)
@@ -466,8 +468,9 @@ class ModifyScanConfigSetName(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None
@@ -533,8 +536,9 @@ class ModifyScanConfigSetComment(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None
@@ -641,8 +645,9 @@ class ModifyScanConfigSetFamilySelection(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None
@@ -744,8 +749,9 @@ class ModifyScanConfigSetNvtPreference(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None
@@ -831,8 +837,9 @@ class ModifyScanConfigSetNvtSelection(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None
@@ -916,8 +923,9 @@ class ModifyScanConfigSetScannerPreference(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         config_id = (
             str(input_object.config_id)
             if input_object.config_id is not None

--- a/selene/schema/scan_configs/queries.py
+++ b/selene/schema/scan_configs/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/scanners/fields.py
+++ b/selene/schema/scanners/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import ScannerType as GvmScannerType
@@ -48,6 +46,7 @@ class Param(graphene.ObjectType):
 
     mandatory = graphene.Boolean()
 
+    @staticmethod
     def resolve_mandatory(root, _info):
         return get_boolean_from_element(root, 'mandatory')
 
@@ -72,9 +71,11 @@ class ScannerInfo(graphene.ObjectType):
 
     params = graphene.List(Param)
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'description')
 
+    @staticmethod
     def resolve_params(root, _info):
         params = root.find('params')
         if len(params) == 0:
@@ -93,9 +94,11 @@ class CaPubInfo(graphene.ObjectType):
     activation_time = graphene.DateTime()
     expiration_time = graphene.DateTime()
 
+    @staticmethod
     def resolve_activation_time(root, _info):
         return get_datetime_from_element(root, 'activation_time')
 
+    @staticmethod
     def resolve_expiration_time(root, _info):
         return get_datetime_from_element(root, 'expiration_time')
 
@@ -105,9 +108,11 @@ class CaPub(graphene.ObjectType):
     certificate = graphene.String()
     info = graphene.Field(CaPubInfo)
 
+    @staticmethod
     def resolve_certificate(root, _info):
         return root.get("certificate")
 
+    @staticmethod
     def resolve_info(root, _info):
         return root.get("info")
 
@@ -143,35 +148,43 @@ class Scanner(EntityObjectType):
         ScannerType, name="type", description="Type of the scanner"
     )
 
+    @staticmethod
     def resolve_host(root, _info):
         return get_text_from_element(root, 'host')
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_text_from_element(root, 'port')
 
+    @staticmethod
     def resolve_configs(root, _info):
         configs = root.find('configs')
         if len(configs) == 0:
             return None
         return configs.findall('config')
 
+    @staticmethod
     def resolve_tasks(root, _info):
         tasks = root.find('tasks')
         if len(tasks) == 0:
             return None
         return tasks.findall('task')
 
+    @staticmethod
     def resolve_ca_pub(parent, _info):
         return {
             "certificate": get_text_from_element(parent, 'ca_pub'),
             "info": parent.find("ca_pub_info"),
         }
 
+    @staticmethod
     def resolve_info(root, _info):
         return root.find('info')
 
+    @staticmethod
     def resolve_credential(root, _info):
         return root.find('credential')
 
+    @staticmethod
     def resolve_type(root, _info):
         return get_text_from_element(root, 'type')

--- a/selene/schema/scanners/mutations.py
+++ b/selene/schema/scanners/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 import graphene
@@ -52,8 +50,9 @@ class DeleteScanner(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, scanner_id):
+    def mutate(_root, info, scanner_id):
         gmp = get_gmp(info)
         gmp.delete_scanner(str(scanner_id))
         return DeleteScanner(ok=True)
@@ -98,8 +97,9 @@ class CreateScanner(graphene.Mutation):
 
     scanner_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         comment = input_object.comment
@@ -110,6 +110,7 @@ class CreateScanner(graphene.Mutation):
             port = input_object.port
         else:
             port = 9391
+        # pylint:disable=no-member
         if scanner_type == ScannerType.OSP_SCANNER_TYPE:
             ca_pub = input_object.ca_pub
         else:
@@ -170,8 +171,9 @@ class ModifyScanner(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         scanner_id = str(input_object.scanner_id)
         name = input_object.name
@@ -183,6 +185,7 @@ class ModifyScanner(graphene.Mutation):
             port = input_object.port
         else:
             port = 9391
+        # pylint:disable=no-member
         if scanner_type == ScannerType.OSP_SCANNER_TYPE:
             ca_pub = input_object.ca_pub
         else:
@@ -207,6 +210,7 @@ class ModifyScanner(graphene.Mutation):
 class VerifyScannerType(graphene.ObjectType):
     version = graphene.String()
 
+    @staticmethod
     def resolve_version(root, _info):
         return get_text_from_element(root, 'version')
 
@@ -247,8 +251,9 @@ class CloneScanner(graphene.Mutation):
 
     scanner_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, scanner_id):
+    def mutate(_root, info, scanner_id):
         gmp = get_gmp(info)
         elem = gmp.clone_scanner(str(scanner_id))
         return CloneScanner(scanner_id=elem.get('id'))

--- a/selene/schema/scanners/queries.py
+++ b/selene/schema/scanners/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/schedules/fields.py
+++ b/selene/schema/schedules/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.resolver import find_resolver
@@ -36,14 +34,17 @@ class Schedule(EntityObjectType):
     tasks = graphene.List(Task)
     timezone = graphene.String()
 
+    @staticmethod
     def resolve_icalendar(root, _info):
         return get_text_from_element(root, 'icalendar')
 
+    @staticmethod
     def resolve_tasks(root, _info):
         tasks = root.find('tasks')
         if len(tasks) == 0:
             return None
         return tasks.findall('task')
 
+    @staticmethod
     def resolve_timezone(root, _info):
         return get_text_from_element(root, 'timezone')

--- a/selene/schema/schedules/mutations.py
+++ b/selene/schema/schedules/mutations.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
-
 import graphene
 
 from selene.schema.utils import require_authentication, get_gmp
@@ -70,8 +67,9 @@ class CreateSchedule(graphene.Mutation):
 
     schedule_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_schedule(
@@ -126,8 +124,9 @@ class ModifySchedule(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         gmp.modify_schedule(
@@ -179,8 +178,9 @@ class CloneSchedule(graphene.Mutation):
     # name here, but it seems working ...?!
     schedule_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, schedule_id):
+    def mutate(_root, info, schedule_id):
         gmp = get_gmp(info)
         elem = gmp.clone_schedule(str(schedule_id))
         return CloneSchedule(schedule_id=elem.get('id'))

--- a/selene/schema/schedules/queries.py
+++ b/selene/schema/schedules/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/severity.py
+++ b/selene/schema/severity.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
+
 from graphql.language import ast
 
 from selene.schema.resolver import text_resolver
@@ -67,9 +66,11 @@ class SeverityRange(graphene.ObjectType):
     minv = SeverityType(name="min")
     maxv = SeverityType(name="max")
 
+    @staticmethod
     def resolve_minv(root, _info):
         return get_text_from_element(root, 'min')
 
+    @staticmethod
     def resolve_maxv(root, _info):
         return get_text_from_element(root, 'max')
 
@@ -85,5 +86,6 @@ class SeverityClass(BaseObjectType):
     full_name = graphene.String()
     severity_ranges = graphene.List(SeverityRange)
 
+    @staticmethod
     def resolve_severity_ranges(root, _info):
         return root.findall('severity_range')

--- a/selene/schema/tags/fields.py
+++ b/selene/schema/tags/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import EntityType as GvmEntityType

--- a/selene/schema/tags/mutations.py
+++ b/selene/schema/tags/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.schema.relay import FilterString
@@ -49,8 +47,9 @@ class CloneTag(graphene.Mutation):
 
     tag_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, copy_id):
+    def mutate(_root, info, copy_id):
         gmp = get_gmp(info)
         resp = gmp.clone_tag(str(copy_id))
         return CloneTag(tag_id=resp.get('id'))
@@ -99,8 +98,9 @@ class CreateTag(graphene.Mutation):
 
     tag_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_tag(
@@ -260,8 +260,9 @@ class ModifyTag(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         if input_object.resource_type is not None:
@@ -305,8 +306,9 @@ class ToggleTag(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         gmp.modify_tag(str(input_object.tag_id), active=input_object.active)
@@ -344,8 +346,9 @@ class RemoveTag(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         gmp.modify_tag(
@@ -388,8 +391,9 @@ class AddTag(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         gmp.modify_tag(
@@ -440,8 +444,9 @@ class BulkTag(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         if input_object.resource_filter is not None:

--- a/selene/schema/tags/queries.py
+++ b/selene/schema/tags/queries.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
 
 from uuid import UUID
 

--- a/selene/schema/targets/fields.py
+++ b/selene/schema/targets/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import AliveTest as GvmAliveTest
@@ -45,6 +43,7 @@ class TargetCredential(BaseObjectType):
 class TargetSSHCredential(TargetCredential):
     port = graphene.Int(description="SSH Port to connect with the credential")
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_int_from_element(root, 'port')
 
@@ -70,15 +69,19 @@ class TargetCredentials(graphene.ObjectType):
         TargetCredential, description="Credential to be used for SNMP logins"
     )
 
+    @staticmethod
     def resolve_ssh(root, _info):
         return root.find('ssh_credential')
 
+    @staticmethod
     def resolve_smb(root, _info):
         return root.find('smb_credential')
 
+    @staticmethod
     def resolve_esxi(root, _info):
         return root.find('esxi_credential')
 
+    @staticmethod
     def resolve_snmp(root, _info):
         return root.find('snmp_credential')
 
@@ -130,35 +133,45 @@ class Target(EntityObjectType):
         TargetCredentials, description="Credentials to use for the scan target"
     )
 
+    @staticmethod
     def resolve_hosts(root, _info):
         hosts = get_text_from_element(root, 'hosts')
         return csv_to_list(hosts)
 
+    @staticmethod
     def resolve_credentials(root, _info):
         return root
 
+    @staticmethod
     def resolve_exclude_hosts(root, _info):
         exclude_hosts = get_text_from_element(root, 'exclude_hosts')
         return csv_to_list(exclude_hosts)
 
+    @staticmethod
     def resolve_host_count(root, _info):
         return get_int_from_element(root, 'max_hosts')
 
+    @staticmethod
     def resolve_port_list(root, _info):
         return root.find("port_list")
 
+    @staticmethod
     def resolve_alive_test(root, _info):
         return get_text_from_element(root, 'alive_tests')
 
+    @staticmethod
     def resolve_allow_simultaneous_ips(root, _info):
         return get_boolean_from_element(root, "allow_simultaneous_ips")
 
+    @staticmethod
     def resolve_reverse_lookup_only(root, _info):
         return get_boolean_from_element(root, "reverse_lookup_only")
 
+    @staticmethod
     def resolve_reverse_lookup_unify(root, _info):
         return get_boolean_from_element(root, "reverse_lookup_unify")
 
+    @staticmethod
     def resolve_tasks(root, _info):
         tasks = root.find('tasks')
         if len(tasks) == 0:

--- a/selene/schema/targets/mutations.py
+++ b/selene/schema/targets/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.errors import InvalidRequest
@@ -118,6 +116,7 @@ class CreateTarget(graphene.Mutation):
 
     target_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
     def mutate(_root, info, input_object):
         name = input_object.name
@@ -255,6 +254,7 @@ class ModifyTarget(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
     def mutate(_root, info, input_object):
         target_id = str(input_object.target_id)
@@ -368,6 +368,7 @@ class DeleteTarget(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
     def mutate(_root, info, target_id):
         gmp = get_gmp(info)
@@ -387,6 +388,7 @@ class CloneTarget(graphene.Mutation):
 
     target_id = graphene.UUID(name='id', description='UUID of the new target')
 
+    @staticmethod
     @require_authentication
     def mutate(_root, info, target_id):
         gmp = get_gmp(info)

--- a/selene/schema/targets/queries.py
+++ b/selene/schema/targets/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/tasks/fields.py
+++ b/selene/schema/tasks/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.resolver import find_resolver, text_resolver
@@ -45,9 +43,11 @@ class TaskReportsCounts(graphene.ObjectType):
         description="Number of finished reports for the task"
     )
 
+    @staticmethod
     def resolve_finished(parent, _info):
         return get_text_from_element(parent, 'finished')
 
+    @staticmethod
     def resolve_total(parent, _info):
         return get_text(parent)
 
@@ -61,24 +61,29 @@ class LastReport(graphene.ObjectType):
     scan_end = graphene.DateTime()
     timestamp = graphene.DateTime()
 
+    @staticmethod
     def resolve_uuid(parent, _info):
         report = parent.find('report')
         uuid = report.get('id')
         return uuid
 
+    @staticmethod
     def resolve_severity(parent, _info):
         report = parent.find('report')
         severity = report.find('severity')
         return get_text(severity)
 
+    @staticmethod
     def resolve_timestamp(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'timestamp')
 
+    @staticmethod
     def resolve_scan_start(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_end')
@@ -92,18 +97,22 @@ class CurrentReport(graphene.ObjectType):
     scan_end = graphene.DateTime()
     timestamp = graphene.DateTime()
 
+    @staticmethod
     def resolve_uuid(parent, _info):
         report = parent.find('report')
         return report.get('id')
 
+    @staticmethod
     def resolve_scan_start(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_start')
 
+    @staticmethod
     def resolve_scan_end(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'scan_end')
 
+    @staticmethod
     def resolve_timestamp(parent, _info):
         report = parent.find('report')
         return get_datetime_from_element(report, 'timestamp')
@@ -122,6 +131,7 @@ class TaskReports(graphene.ObjectType):
     class Meta:
         default_resolver = find_resolver
 
+    @staticmethod
     def resolve_counts(root, _info):
         return get_subelement(root, 'report_count')
 
@@ -130,6 +140,7 @@ class TaskSubObjectType(BaseObjectType):
 
     trash = graphene.Boolean()
 
+    @staticmethod
     def resolve_trash(root, _info):
         return get_boolean_from_element(root, 'trash')
 
@@ -140,6 +151,7 @@ class TaskScanConfig(TaskSubObjectType):
         name="type", description="Type of the scan config"
     )
 
+    @staticmethod
     def resolve_scan_config_type(parent, _info):
         return get_int_from_element(parent, 'type')
 
@@ -149,6 +161,7 @@ class TaskScanner(TaskSubObjectType):
         ScannerType, name="type", description="Type of the scanner"
     )
 
+    @staticmethod
     def resolve_scanner_type(root, _info):
         return get_text_from_element(root, 'type')
 
@@ -158,15 +171,18 @@ class Observers(graphene.ObjectType):
     groups = graphene.List(BaseObjectType)
     roles = graphene.List(BaseObjectType)
 
+    @staticmethod
     def resolve_users(root, _info):
         user_string = get_text(root)
         if not user_string:
             return None
         return user_string.split(' ')
 
+    @staticmethod
     def resolve_groups(root, _info):
         return root.findall('group')
 
+    @staticmethod
     def resolve_roles(root, _info):
         return root.findall('role')
 
@@ -179,6 +195,7 @@ class TaskSchedule(TaskSubObjectType):
     duration = graphene.Int()
     timezone = graphene.String()
 
+    @staticmethod
     def resolve_duration(root, _info):
         return get_int_from_element(root, 'duration')
 
@@ -191,9 +208,11 @@ class TaskPreference(graphene.ObjectType):
     name = graphene.String()
     value = graphene.String()
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'scanner_name')
 
+    @staticmethod
     def resolve_description(root, _info):
         return get_text_from_element(root, 'name')
 
@@ -203,6 +222,7 @@ class BaseCounts(graphene.ObjectType):
 
 
 class TaskResultsCounts(BaseCounts):
+    @staticmethod
     def resolve_current(current: int, _info):
         return current
 
@@ -210,6 +230,7 @@ class TaskResultsCounts(BaseCounts):
 class TaskResults(graphene.ObjectType):
     counts = graphene.Field(TaskResultsCounts)
 
+    @staticmethod
     def resolve_counts(result_count: XmlElement, _info):
         current = get_text(result_count)
         return parse_int(current)
@@ -249,53 +270,68 @@ class Task(EntityObjectType):
     reports = graphene.Field(TaskReports)
     results = graphene.Field(TaskResults)
 
+    @staticmethod
     def resolve_average_duration(root, _info):
         return get_int_from_element(root, 'average_duration')
 
+    @staticmethod
     def resolve_trend(root, _info):
         return get_text_from_element(root, 'trend')
 
+    @staticmethod
     def resolve_status(root, _info):
         return get_text_from_element(root, 'status')
 
+    @staticmethod
     def resolve_alterable(root, _info):
         return get_boolean_from_element(root, 'alterable')
 
+    @staticmethod
     def resolve_hosts_ordering(root, _info):
         return get_text_from_element(root, 'hosts_ordering')
 
+    @staticmethod
     def resolve_progress(root, _info):
         return get_int_from_element(root, 'progress')
 
+    @staticmethod
     def resolve_scan_config(root, _info):
         return get_sub_element_if_id_available(root, 'config')
 
+    @staticmethod
     def resolve_target(root, _info):
         return get_sub_element_if_id_available(root, 'target')
 
+    @staticmethod
     def resolve_scanner(root, _info):
         return get_sub_element_if_id_available(root, 'scanner')
 
+    @staticmethod
     def resolve_alerts(root, _info):
         alerts = root.findall('alert')
         if not alerts:
             return None
         return alerts
 
+    @staticmethod
     def resolve_schedule(root, _info):
         return get_sub_element_if_id_available(root, 'schedule')
 
+    @staticmethod
     def resolve_schedule_periods(root, _info):
         return get_int_from_element(root, 'schedule_periods')
 
+    @staticmethod
     def resolve_preferences(root, _info):
         preferences = root.find('preferences')
         if preferences is None:
             return None
         return preferences.findall('preference')
 
+    @staticmethod
     def resolve_results(root, _info):
         return get_subelement(root, 'result_count')
 
+    @staticmethod
     def resolve_reports(root, _info):
         return root

--- a/selene/schema/tasks/mutations.py
+++ b/selene/schema/tasks/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import (
@@ -59,8 +57,9 @@ class CloneTask(graphene.Mutation):
 
     task_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, task_id):
+    def mutate(_root, info, task_id):
         gmp = get_gmp(info)
         elem = gmp.clone_task(str(task_id))
         return CloneTask(task_id=elem.get('id'))
@@ -81,8 +80,9 @@ class DeleteTask(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, task_id):
+    def mutate(_root, info, task_id):
         gmp = get_gmp(info)
         gmp.delete_task(str(task_id))
         return DeleteTask(ok=True)
@@ -131,8 +131,9 @@ class CreateContainerTask(graphene.Mutation):
 
     task_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object: CreateContainerTaskInput):
+    def mutate(_root, info, input_object: CreateContainerTaskInput):
         gmp = get_gmp(info)
 
         resp = gmp.create_container_task(
@@ -260,8 +261,9 @@ class CreateTask(graphene.Mutation):
 
     task_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         name = input_object.name
         alterable = input_object.alterable
@@ -475,8 +477,9 @@ class ModifyTask(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         task_id = str(input_object.task_id)
         name = input_object.name
@@ -586,8 +589,9 @@ class StartTask(graphene.Mutation):
 
     report_id = graphene.UUID()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, task_id):
+    def mutate(_root, info, task_id):
         gmp = get_gmp(info)
         resp = gmp.start_task(str(task_id))
 
@@ -610,8 +614,9 @@ class StopTask(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, task_id):
+    def mutate(_root, info, task_id):
         gmp = get_gmp(info)
         resp = gmp.stop_task(str(task_id))
         status = int(resp.get('status'))
@@ -634,8 +639,9 @@ class ResumeTask(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, task_id):
+    def mutate(_root, info, task_id):
         gmp = get_gmp(info)
         resp = gmp.resume_task(str(task_id))
         status = int(resp.get('status'))

--- a/selene/schema/tasks/queries.py
+++ b/selene/schema/tasks/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/tickets/fields.py
+++ b/selene/schema/tickets/fields.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from gvm.protocols.next import TicketStatus as GvmTicketStatus
+
 from selene.schema.resolver import text_resolver
 
 from selene.schema.parser import parse_uuid
@@ -43,9 +42,11 @@ class TicketReport(graphene.ObjectType):
     id = graphene.UUID()
     timestamp = graphene.DateTime()
 
+    @staticmethod
     def resolve_id(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_timestamp(root, _info):
         return get_datetime_from_element(root, 'timestamp')
 
@@ -78,29 +79,38 @@ class RemediationTicket(EntityObjectType):
     result = graphene.UUID()
     orphan = graphene.Boolean()
 
+    @staticmethod
     def resolve_assigned_to(root, _info):
         return root.find('assigned_to').find('user')
 
+    @staticmethod
     def resolve_open_time(root, _info):
         return get_datetime_from_element(root, 'open_time')
 
+    @staticmethod
     def resolve_fixed_time(root, _info):
         return get_datetime_from_element(root, 'fixed_time')
 
+    @staticmethod
     def resolve_closed_time(root, _info):
         return get_datetime_from_element(root, 'closed_time')
 
+    @staticmethod
     def resolve_nvt_oid(root, _info):
         return root.find('nvt').get('oid')
 
+    @staticmethod
     def resolve_task(root, _info):
         return root.find("task")
 
+    @staticmethod
     def resolve_report(root, _info):
         return root.find('report')
 
+    @staticmethod
     def resolve_result(root, _info):
         return parse_uuid(root.find('result').get('id'))
 
+    @staticmethod
     def resolve_orphan(root, _info):
         return get_boolean_from_element(root, 'orphan')

--- a/selene/schema/tickets/mutations.py
+++ b/selene/schema/tickets/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.entities import (
@@ -46,8 +44,9 @@ class CloneTicket(graphene.Mutation):
 
     ticket_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, ticket_id):
+    def mutate(_root, info, ticket_id):
         gmp = get_gmp(info)
         elem = gmp.clone_ticket(str(ticket_id))
         return CloneTicket(ticket_id=elem.get('id'))
@@ -116,8 +115,9 @@ class CreateTicket(graphene.Mutation):
 
     ticket_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         note = input_object.note
         comment = input_object.comment
@@ -178,8 +178,9 @@ class ModifyTicket(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
 
         ticket_id = str(input_object.ticket_id)
 

--- a/selene/schema/tickets/queries.py
+++ b/selene/schema/tickets/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
 
 from graphql import ResolveInfo

--- a/selene/schema/tls_certificates/fields.py
+++ b/selene/schema/tls_certificates/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import (
@@ -36,17 +34,21 @@ class TLSSourceLocation(graphene.ObjectType):
     host_id = graphene.UUID()
     port = graphene.Int()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_host_ip(root, _info):
         host = root.find('host')
         return get_text_from_element(host, 'ip')
 
+    @staticmethod
     def resolve_host_id(root, _info):
         host = root.find('host')
         return parse_uuid(host.find('asset').get('id'))
 
+    @staticmethod
     def resolve_port(root, _info):
         return get_int_from_element(root, 'port')
 
@@ -57,15 +59,19 @@ class TLSSourceOrigin(graphene.ObjectType):
     origin_id = graphene.UUID()
     origin_data = graphene.String()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_origin_type(root, _info):
         return get_text_from_element(root, 'origin_type')
 
+    @staticmethod
     def resolve_origin_id(root, _info):
         return get_text_from_element(root, 'origin_id')
 
+    @staticmethod
     def resolve_origin_data(root, _info):
         return get_text_from_element(root, 'origin_data')
 
@@ -77,18 +83,23 @@ class TLSSource(graphene.ObjectType):
     location = graphene.Field(TLSSourceLocation)
     origin = graphene.Field(TLSSourceOrigin)
 
+    @staticmethod
     def resolve_uuid(root, _info):
         return parse_uuid(root.get('id'))
 
+    @staticmethod
     def resolve_timestamp(root, _info):
         return get_datetime_from_element(root, 'timestamp')
 
+    @staticmethod
     def resolve_tls_versions(root, _info):
         return get_text_from_element(root, 'tls_versions').split(', ')
 
+    @staticmethod
     def resolve_location(root, _info):
         return root.find('location')
 
+    @staticmethod
     def resolve_origin(root, _info):
         return root.find('origin')
 
@@ -111,45 +122,59 @@ class TLSCertificate(EntityObjectType):
     last_seen = graphene.DateTime()
     sources = graphene.List(TLSSource)
 
+    @staticmethod
     def resolve_certificate_format(root, _info):
         return root.find('certificate').get('format')
 
+    @staticmethod
     def resolve_certificate(root, _info):
         return get_text_from_element(root, 'certificate')
 
+    @staticmethod
     def resolve_sha256_fingerprint(root, _info):
         return get_text_from_element(root, 'sha256_fingerprint')
 
+    @staticmethod
     def resolve_md5_fingerprint(root, _info):
         return get_text_from_element(root, 'md5_fingerprint')
 
+    @staticmethod
     def resolve_trust(root, _info):
         return get_boolean_from_element(root, 'trust')
 
+    @staticmethod
     def resolve_valid(root, _info):
         return get_boolean_from_element(root, 'valid')
 
+    @staticmethod
     def resolve_time_status(root, _info):
         return get_text_from_element(root, 'time_status')
 
+    @staticmethod
     def resolve_activation_time(root, _info):
         return get_datetime_from_element(root, 'activation_time')
 
+    @staticmethod
     def resolve_expiration_time(root, _info):
         return get_datetime_from_element(root, 'expiration_time')
 
+    @staticmethod
     def resolve_subject_dn(root, _info):
         return get_text_from_element(root, 'subject_dn')
 
+    @staticmethod
     def resolve_issuer_dn(root, _info):
         return get_text_from_element(root, 'issuer_dn')
 
+    @staticmethod
     def resolve_serial(root, _info):
         return get_text_from_element(root, 'serial')
 
+    @staticmethod
     def resolve_last_seen(root, _info):
         return get_datetime_from_element(root, 'last_seen')
 
+    @staticmethod
     def resolve_sources(root, _info):
         sources = root.find('sources')
         if sources is not None:

--- a/selene/schema/tls_certificates/mutations.py
+++ b/selene/schema/tls_certificates/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.schema.entities import (
@@ -55,8 +53,9 @@ class CreateTLSCertificate(graphene.Mutation):
 
     tls_certificate_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         resp = gmp.create_tls_certificate(
@@ -84,8 +83,9 @@ class CloneTLSCertificate(graphene.Mutation):
 
     cloned_tls_certificate_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, tls_certificate_id):
+    def mutate(_root, info, tls_certificate_id):
         gmp = get_gmp(info)
         resp = gmp.clone_tls_certificate(str(tls_certificate_id))
         return CloneTLSCertificate(cloned_tls_certificate_id=resp.get('id'))
@@ -106,8 +106,9 @@ class DeleteTLSCertificate(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, tls_certificate_id):
+    def mutate(_root, info, tls_certificate_id):
         gmp = get_gmp(info)
         gmp.delete_tls_certificate(str(tls_certificate_id))
         return DeleteTLSCertificate(ok=True)
@@ -237,8 +238,9 @@ class ModifyTLSCertificate(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         tls_certificate_id = (
             str(input_object.tls_certificate_id)
             if input_object.tls_certificate_id is not None

--- a/selene/schema/tls_certificates/queries.py
+++ b/selene/schema/tls_certificates/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene

--- a/selene/schema/trash/mutations.py
+++ b/selene/schema/trash/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 import graphene
 
 from selene.schema.utils import get_gmp, require_authentication
@@ -32,8 +30,9 @@ class EmptyTrashcan(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info):
+    def mutate(_root, info):
         gmp = get_gmp(info)
         gmp.empty_trashcan()
         return EmptyTrashcan(ok=True)
@@ -55,8 +54,9 @@ class RestoreFromTrashcan(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, restore_id):
+    def mutate(_root, info, restore_id):
         gmp = get_gmp(info)
         gmp.restore(str(restore_id))
         return EmptyTrashcan(ok=True)

--- a/selene/schema/user_settings/fields.py
+++ b/selene/schema/user_settings/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.utils import get_text_from_element
@@ -31,15 +29,19 @@ class UserSetting(graphene.ObjectType):
     uuid = graphene.String(name='id')
     name = graphene.String()
 
+    @staticmethod
     def resolve_uuid(root, _info):
         entity_id = root.get('id')
         return entity_id
 
+    @staticmethod
     def resolve_name(root, _info):
         return get_text_from_element(root, 'name')
 
+    @staticmethod
     def resolve_comment(root, _info):
         return get_text_from_element(root, 'comment')
 
+    @staticmethod
     def resolve_value(root, _info):
         return get_text_from_element(root, 'value')

--- a/selene/schema/user_settings/queries.py
+++ b/selene/schema/user_settings/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.user_settings.fields import UserSetting

--- a/selene/schema/users/fields.py
+++ b/selene/schema/users/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import string
 
 import graphene
@@ -34,6 +32,7 @@ class UserRole(BaseRoleType):
 
     permissions = graphene.List(EntityPermission)
 
+    @staticmethod
     def resolve_permissions(root, _info):
         permissions = root.find('permissions')
         if permissions is None:
@@ -44,6 +43,7 @@ class UserRole(BaseRoleType):
 class UserGroup(BaseObjectType):
     permissions = graphene.List(EntityPermission)
 
+    @staticmethod
     def resolve_permissions(root, _info):
         permissions = root.find('permissions')
         if permissions is None:
@@ -69,18 +69,21 @@ class User(EntityObjectType):
         description="Sources allowed for" "authentication for this user.",
     )
 
+    @staticmethod
     def resolve_roles(root, _info):
         roles = root.findall('role')
         if not roles or roles is None:
             return None
         return roles
 
+    @staticmethod
     def resolve_group_list(root, _info):
         groups = root.find("groups")
         if groups is None:
             return None
         return groups.findall("group")
 
+    @staticmethod
     def resolve_host_list(root, _info):
         hosts_string = get_text_from_element(root, 'hosts')
         if not hosts_string:
@@ -90,10 +93,12 @@ class User(EntityObjectType):
         )
         return hosts_string.split(',')
 
+    @staticmethod
     def resolve_hosts_allow(root, _info):
         hosts = root.find("hosts")
         return bool(int(hosts.get("allow")))
 
+    @staticmethod
     def resolve_iface_list(root, _info):
         ifaces_string = get_text_from_element(root, 'ifaces')
         if not ifaces_string:
@@ -103,10 +108,12 @@ class User(EntityObjectType):
         )
         return ifaces_string.split(',')
 
+    @staticmethod
     def resolve_ifaces_allow(root, _info):
         ifaces = root.find("ifaces")
         return bool(int(ifaces.get("allow")))
 
+    @staticmethod
     def resolve_sources(root, _info):
         sources_list_xml = root.find('sources').findall('source')
         sources_list = []

--- a/selene/schema/users/mutations.py
+++ b/selene/schema/users/mutations.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
+import string
 
 from enum import auto
-import string
 
 import graphene
 
@@ -71,8 +70,9 @@ class CloneUser(graphene.Mutation):
 
     user_id = graphene.UUID(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, user_id):
+    def mutate(_root, info, user_id):
         gmp = get_gmp(info)
         elem = gmp.clone_user(str(user_id))
         return CloneUser(user_id=elem.get('id'))
@@ -159,8 +159,9 @@ class CreateUser(graphene.Mutation):
 
     id_of_created_user = graphene.String(name='id')
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         gmp = get_gmp(info)
 
         name = input_object.name if input_object.name is not None else None
@@ -222,8 +223,9 @@ class DeleteUsersByFilter(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         filter_string = (
             input_object.filter_string
             if input_object.filter_string is not None
@@ -284,8 +286,9 @@ class DeleteUsersByIds(graphene.Mutation):
 
     ok = graphene.Boolean()
 
+    @staticmethod
     @require_authentication
-    def mutate(root, info, input_object):
+    def mutate(_root, info, input_object):
         user_ids = (
             input_object.user_ids if input_object.user_ids is not None else None
         )
@@ -420,8 +423,9 @@ def create_modify_user_mutation(
     field_to_modify=None,
 ):
     class ModifyUser(graphene.Mutation, AbstractModifyUser):
+        @staticmethod
         @require_authentication
-        def mutate(root, info, input_object):
+        def mutate(_root, info, input_object):
             gmp = get_gmp(info)
 
             # No fields given to be modify

--- a/selene/schema/users/queries.py
+++ b/selene/schema/users/queries.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from uuid import UUID
+
 import graphene
 
 from graphql import ResolveInfo
+
 from selene.schema.parser import FilterString
 
 from selene.schema.utils import get_gmp, require_authentication, XmlElement

--- a/selene/schema/vulnerabilities/fields.py
+++ b/selene/schema/vulnerabilities/fields.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 import graphene
 
 from selene.schema.resolver import text_resolver
@@ -36,12 +34,15 @@ class VulnerabilityResults(graphene.ObjectType):
     oldest = graphene.DateTime()
     newest = graphene.DateTime()
 
+    @staticmethod
     def resolve_count(root, _info):
         return get_int_from_element(root, 'count')
 
+    @staticmethod
     def resolve_oldest(root, _info):
         return get_datetime_from_element(root, 'oldest')
 
+    @staticmethod
     def resolve_newest(root, _info):
         return get_datetime_from_element(root, 'newest')
 
@@ -60,24 +61,31 @@ class Vulnerability(graphene.ObjectType):
     results = graphene.Field(VulnerabilityResults)
     host_count = graphene.Int()
 
+    @staticmethod
     def resolve_vuln_id(root, _info):
         return root.get('id')
 
+    @staticmethod
     def resolve_vuln_type(root, _info):
         return get_text_from_element(root, 'type')
 
+    @staticmethod
     def resolve_creation_time(root, _info):
         return get_datetime_from_element(root, 'creation_time')
 
+    @staticmethod
     def resolve_modification_time(root, _info):
         return get_datetime_from_element(root, 'modification_time')
 
+    @staticmethod
     def resolve_host_count(root, _info):
         hosts = root.find('hosts')
         return get_int_from_element(hosts, 'count')
 
+    @staticmethod
     def resolve_results(root, _info):
         return root.find('results')
 
+    @staticmethod
     def resolve_qod(root, _info):
         return get_int_from_element(root, 'qod')

--- a/selene/schema/vulnerabilities/mutations.py
+++ b/selene/schema/vulnerabilities/mutations.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument, no-member
-
 from selene.schema.entities import (
     create_export_by_ids_mutation,
     create_export_by_filter_mutation,

--- a/selene/schema/vulnerabilities/queries.py
+++ b/selene/schema/vulnerabilities/queries.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-self-argument
-
 from uuid import UUID
 
 import graphene


### PR DESCRIPTION
**What**:

Use explicit static method decorators to avoid having to disable no-self-argument warning for pylint. 

**Why**:

It could be possible that at another non-resolver method a developer forgets about the self param and pylint wouldn't warn in this case. Therefore it is better to make the methods static explicitly.

**How**:

Run pylint

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- n/a [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- n/a Documentation
