### PR TITLE
Fix crash if port list has no targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ $ cd hyperion && git log
 
 ### Fixed
 
+- Fixed crash if targets of a port list have been created from a post list without targets [#134](https://github.com/greenbone/hyperion/pull/134)
 - Fixed a problem with NVT `oid` in Notes. [#15](https://github.com/greenbone/hyperion/pull/15)
 - Fixed a problem with NVT `oid` in Overrides. [#16](https://github.com/greenbone/hyperion/pull/16)
 - Now the `name` field in Overrides and Notes can not be queried. It returned the `name` of the `permission`/`owner` because of `.find()`. Notes/Overrides don't have a name field theirself. [#16](https://github.com/greenbone/hyperion/pull/16)

--- a/selene/schema/port_list/fields.py
+++ b/selene/schema/port_list/fields.py
@@ -118,6 +118,6 @@ class PortList(EntityObjectType):
     @staticmethod
     def resolve_targets(root, _info):
         targets = root.find('targets')
-        if len(targets) == 0:
+        if targets is None or len(targets) == 0:
             return None
         return targets.findall('target')

--- a/selene/tests/port_lists/test_get_port_list.py
+++ b/selene/tests/port_lists/test_get_port_list.py
@@ -332,3 +332,217 @@ class PortListTestCase(SeleneTestCase):
         self.assertEqual(port_list_counts['all'], 42)
         self.assertEqual(port_list_counts['tcp'], 21)
         self.assertEqual(port_list_counts['udp'], 21)
+
+    def test_get_port_list_no_target(self, mock_gmp: GmpMockFactory):
+        mock_gmp.mock_response(
+            'get_port_list',
+            '''
+            <get_port_lists_response>
+                <port_list id="4a4717fe-57d2-11e1-9a26-406186ea4fc5">
+                    <name>All IANA assigned TCP and UDP</name>
+                    <owner><name>Palpatine</name></owner>
+                    <creation_time>2020-06-30T09:16:25Z</creation_time>
+                    <modification_time>2020-07-30T09:16:25Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>1</in_use>
+                    <port_count>
+                        <all>42</all>
+                        <tcp>21</tcp>
+                        <udp>21</udp>
+                    </port_count>
+                    <port_ranges>
+                        <port_range id="2864fa44-594a-45d5-88ee-6c9742481b8e">
+                            <start>1</start>
+                            <end>3</end>
+                            <type>tcp</type>
+                        </port_range>
+                        <port_range id="6390a473-86b3-4583-b4b9-e7e3b2a55355">
+                            <start>5</start>
+                            <end>5</end>
+                            <type>udp</type>
+                        </port_range>
+                    </port_ranges>
+                    <targets>
+                    </targets>
+                </port_list>
+            </get_port_lists_response>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            '''
+            query {
+                portList(id: "4a4717fe-57d2-11e1-9a26-406186ea4fc5") {
+                    name
+                    id
+                    owner
+                    creationTime
+                    modificationTime
+                    writable
+                    inUse
+                    portCount {
+                        all
+                        tcp
+                        udp
+                    }
+                    portRanges {
+                        id
+                        start
+                        end
+                        type
+                    }
+                    targets {
+                        id
+                        name
+                    }
+                }
+            }
+            '''
+        )
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        port_list = json['data']['portList']
+
+        self.assertEqual(
+            port_list['id'], '4a4717fe-57d2-11e1-9a26-406186ea4fc5'
+        )
+        self.assertEqual(port_list['owner'], 'Palpatine')
+        self.assertEqual(port_list['creationTime'], '2020-06-30T09:16:25+00:00')
+        self.assertEqual(
+            port_list['modificationTime'], '2020-07-30T09:16:25+00:00'
+        )
+        self.assertEqual(port_list['writable'], True)
+        self.assertEqual(port_list['inUse'], True)
+        self.assertEqual(port_list['name'], 'All IANA assigned TCP and UDP')
+
+        targets = port_list['targets']
+        self.assertIsNone(targets)
+
+        port_ranges = port_list['portRanges']
+        self.assertEqual(
+            port_ranges[0]['id'], '2864fa44-594a-45d5-88ee-6c9742481b8e'
+        )
+        self.assertEqual(port_ranges[0]['start'], 1)
+        self.assertEqual(port_ranges[0]['end'], 3)
+        self.assertEqual(port_ranges[0]['type'], 'TCP')
+        self.assertEqual(
+            port_ranges[1]['id'], '6390a473-86b3-4583-b4b9-e7e3b2a55355'
+        )
+        self.assertEqual(port_ranges[1]['start'], 5)
+        self.assertEqual(port_ranges[1]['end'], 5)
+        self.assertEqual(port_ranges[1]['type'], 'UDP')
+
+        port_list_counts = port_list['portCount']
+        self.assertEqual(port_list_counts['all'], 42)
+        self.assertEqual(port_list_counts['tcp'], 21)
+        self.assertEqual(port_list_counts['udp'], 21)
+
+    def test_get_port_list_no_targets(self, mock_gmp: GmpMockFactory):
+        mock_gmp.mock_response(
+            'get_port_list',
+            '''
+            <get_port_lists_response>
+                <port_list id="4a4717fe-57d2-11e1-9a26-406186ea4fc5">
+                    <name>All IANA assigned TCP and UDP</name>
+                    <owner><name>Palpatine</name></owner>
+                    <creation_time>2020-06-30T09:16:25Z</creation_time>
+                    <modification_time>2020-07-30T09:16:25Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>1</in_use>
+                    <port_count>
+                        <all>42</all>
+                        <tcp>21</tcp>
+                        <udp>21</udp>
+                    </port_count>
+                    <port_ranges>
+                        <port_range id="2864fa44-594a-45d5-88ee-6c9742481b8e">
+                            <start>1</start>
+                            <end>3</end>
+                            <type>tcp</type>
+                        </port_range>
+                        <port_range id="6390a473-86b3-4583-b4b9-e7e3b2a55355">
+                            <start>5</start>
+                            <end>5</end>
+                            <type>udp</type>
+                        </port_range>
+                    </port_ranges>
+                </port_list>
+            </get_port_lists_response>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            '''
+            query {
+                portList(id: "4a4717fe-57d2-11e1-9a26-406186ea4fc5") {
+                    name
+                    id
+                    owner
+                    creationTime
+                    modificationTime
+                    writable
+                    inUse
+                    portCount {
+                        all
+                        tcp
+                        udp
+                    }
+                    portRanges {
+                        id
+                        start
+                        end
+                        type
+                    }
+                    targets {
+                        id
+                        name
+                    }
+                }
+            }
+            '''
+        )
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        port_list = json['data']['portList']
+
+        self.assertEqual(
+            port_list['id'], '4a4717fe-57d2-11e1-9a26-406186ea4fc5'
+        )
+        self.assertEqual(port_list['owner'], 'Palpatine')
+        self.assertEqual(port_list['creationTime'], '2020-06-30T09:16:25+00:00')
+        self.assertEqual(
+            port_list['modificationTime'], '2020-07-30T09:16:25+00:00'
+        )
+        self.assertEqual(port_list['writable'], True)
+        self.assertEqual(port_list['inUse'], True)
+        self.assertEqual(port_list['name'], 'All IANA assigned TCP and UDP')
+
+        targets = port_list['targets']
+        self.assertIsNone(targets)
+
+        port_ranges = port_list['portRanges']
+        self.assertEqual(
+            port_ranges[0]['id'], '2864fa44-594a-45d5-88ee-6c9742481b8e'
+        )
+        self.assertEqual(port_ranges[0]['start'], 1)
+        self.assertEqual(port_ranges[0]['end'], 3)
+        self.assertEqual(port_ranges[0]['type'], 'TCP')
+        self.assertEqual(
+            port_ranges[1]['id'], '6390a473-86b3-4583-b4b9-e7e3b2a55355'
+        )
+        self.assertEqual(port_ranges[1]['start'], 5)
+        self.assertEqual(port_ranges[1]['end'], 5)
+        self.assertEqual(port_ranges[1]['type'], 'UDP')
+
+        port_list_counts = port_list['portCount']
+        self.assertEqual(port_list_counts['all'], 42)
+        self.assertEqual(port_list_counts['tcp'], 21)
+        self.assertEqual(port_list_counts['udp'], 21)


### PR DESCRIPTION
**What**:

Check if port list response contains a `<targets>` element before accessing it. 

**Why**:

Don't crash when trying to get the targets of a port list.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- n/a Documentation
