### PR TITLE
Fix various typos.

### DIFF
--- a/selene/schema/audits/fields.py
+++ b/selene/schema/audits/fields.py
@@ -187,7 +187,9 @@ class AuditResults(graphene.ObjectType):
 
 class AuditSubObjectType(BaseObjectType):
 
-    trash = graphene.Boolean(description="Whether the object is in the trashcan")
+    trash = graphene.Boolean(
+        description="Whether the object is in the trashcan"
+    )
 
     @staticmethod
     def resolve_trash(root, _info):

--- a/selene/schema/audits/fields.py
+++ b/selene/schema/audits/fields.py
@@ -187,7 +187,7 @@ class AuditResults(graphene.ObjectType):
 
 class AuditSubObjectType(BaseObjectType):
 
-    trash = graphene.Boolean(description="Wether the object is in the trashcan")
+    trash = graphene.Boolean(description="Whether the object is in the trashcan")
 
     @staticmethod
     def resolve_trash(root, _info):
@@ -217,7 +217,7 @@ class AuditSchedule(AuditSubObjectType):
         default_resolver = text_resolver
 
     icalendar = graphene.String(
-        description="Calender information for an audit in the iCal format"
+        description="Calendar information for an audit in the iCal format"
     )
     duration = graphene.Int(
         description="Maximum duration of a schedule in seconds. A scheduled "
@@ -362,9 +362,9 @@ class Audit(EntityObjectType):
         description="Status of the last or current scan of the audit",
     )
 
-    alterable = graphene.Boolean(description="Wether the audit is alterable")
+    alterable = graphene.Boolean(description="Whether the audit is alterable")
 
-    progress = graphene.Int(description="Progess of the current scan")
+    progress = graphene.Int(description="Progress of the current scan")
 
     policy = graphene.Field(
         AuditPolicy, description="Used policy for the audit"

--- a/selene/schema/tasks/fields.py
+++ b/selene/schema/tasks/fields.py
@@ -154,7 +154,7 @@ class TaskReports(graphene.ObjectType):
 
 class TaskSubObjectType(BaseObjectType):
 
-    trash = graphene.Boolean(description="Wether the object is in the trashcan")
+    trash = graphene.Boolean(description="Whether the object is in the trashcan")
 
     @staticmethod
     def resolve_trash(root, _info):
@@ -217,7 +217,7 @@ class TaskSchedule(TaskSubObjectType):
         default_resolver = text_resolver
 
     icalendar = graphene.String(
-        description="Calender information for a task in the iCal format"
+        description="Calendar information for a task in the iCal format"
     )
     duration = graphene.Int(
         description="Maximum duration of a schedule in seconds. A scheduled "
@@ -362,9 +362,9 @@ class Task(EntityObjectType):
         TaskStatus, description="Status of the last or current scan of the task"
     )
 
-    alterable = graphene.Boolean(description="Wether the task is alterable")
+    alterable = graphene.Boolean(description="Whether the task is alterable")
 
-    progress = graphene.Int(description="Progess of the current scan")
+    progress = graphene.Int(description="Progress of the current scan")
 
     scan_config = graphene.Field(
         TaskScanConfig, description="Used scan config for the task"

--- a/selene/schema/tasks/fields.py
+++ b/selene/schema/tasks/fields.py
@@ -154,7 +154,9 @@ class TaskReports(graphene.ObjectType):
 
 class TaskSubObjectType(BaseObjectType):
 
-    trash = graphene.Boolean(description="Whether the object is in the trashcan")
+    trash = graphene.Boolean(
+        description="Whether the object is in the trashcan"
+    )
 
     @staticmethod
     def resolve_trash(root, _info):


### PR DESCRIPTION
Found via codespell:

```
./selene/schema/audits/fields.py:190: Wether ==> Weather, whether
./selene/schema/audits/fields.py:220: Calender ==> Calendar
./selene/schema/audits/fields.py:365: Wether ==> Weather, whether
./selene/schema/audits/fields.py:367: Progess ==> Progress
./selene/schema/tasks/fields.py:157: Wether ==> Weather, whether
./selene/schema/tasks/fields.py:220: Calender ==> Calendar
./selene/schema/tasks/fields.py:365: Wether ==> Weather, whether
./selene/schema/tasks/fields.py:367: Progess ==> Progress
```