### PR TITLE
Allow to deactivate auto delete of reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ $ cd hyperion && git log
 
 ### Changed
 
-- Revisit audit and task object types [#133](https://github.com/greenbone/hyperion/pull/133)
+- Revisit audit and task object types [#133](https://github.com/greenbone/hyperion/pull/133), [#149](https://github.com/greenbone/hyperion/pull/149)
 - Revisit authentication methods [#93](https://github.com/greenbone/hyperion/pull/93)
 - Revisit port list object type, queries and mutations [#108](https://github.com/greenbone/hyperion/pull/108)
 - Revisit feed status object types [#95](https://github.com/greenbone/hyperion/pull/95), [#122](https://github.com/greenbone/hyperion/pull/122)

--- a/selene/schema/audits/mutations.py
+++ b/selene/schema/audits/mutations.py
@@ -202,48 +202,39 @@ class CreateAudit(graphene.Mutation):
         preferences = {}
 
         input_preferences = input_object.preferences
+        if input_preferences:
+            if input_preferences.create_assets_apply_overrides is not None:
+                preferences['assets_apply_overrides'] = to_yes_no(
+                    input_preferences.create_assets_apply_overrides
+                )
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_apply_overrides is not None
-        ):
-            preferences['assets_apply_overrides'] = to_yes_no(
-                input_preferences.create_assets_apply_overrides
-            )
+            if input_preferences.create_assets_min_qod is not None:
+                preferences[
+                    'assets_min_qod'
+                ] = input_preferences.create_assets_min_qod
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_min_qod is not None
-        ):
-            preferences[
-                'assets_min_qod'
-            ] = input_preferences.create_assets_min_qod
+            if input_preferences.auto_delete_reports is not None:
+                preferences['auto_delete'] = "keep"
+                preferences[
+                    'auto_delete_data'
+                ] = input_preferences.auto_delete_reports
+            else:
+                preferences['auto_delete'] = "no"
 
-        if (
-            input_preferences
-            and input_preferences.auto_delete_reports is not None
-        ):
-            preferences['auto_delete'] = "keep"
-            preferences[
-                'auto_delete_data'
-            ] = input_preferences.auto_delete_reports
+            if input_preferences.create_assets is not None:
+                preferences['in_assets'] = to_yes_no(
+                    input_preferences.create_assets
+                )
 
-        if input_preferences and input_preferences.create_assets is not None:
-            preferences['in_assets'] = to_yes_no(
-                input_preferences.create_assets
-            )
+            if input_preferences.max_concurrent_nvts is not None:
+                preferences[
+                    'max_checks'
+                ] = input_preferences.max_concurrent_nvts
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_nvts is not None
-        ):
-            preferences['max_checks'] = input_preferences.max_concurrent_nvts
-
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_hosts is not None
-        ):
-            preferences['max_hosts'] = input_preferences.max_concurrent_hosts
+            if input_preferences.max_concurrent_hosts is not None:
+                preferences[
+                    'max_hosts'
+                ] = input_preferences.max_concurrent_hosts
 
         gmp = get_gmp(info)
 
@@ -353,48 +344,39 @@ class ModifyAudit(graphene.Mutation):
 
         preferences = {}
         input_preferences = input_object.preferences
+        if input_preferences:
+            if input_preferences.create_assets_apply_overrides is not None:
+                preferences['assets_apply_overrides'] = to_yes_no(
+                    input_preferences.create_assets_apply_overrides
+                )
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_apply_overrides is not None
-        ):
-            preferences['assets_apply_overrides'] = to_yes_no(
-                input_preferences.create_assets_apply_overrides
-            )
+            if input_preferences.create_assets_min_qod is not None:
+                preferences[
+                    'assets_min_qod'
+                ] = input_preferences.create_assets_min_qod
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_min_qod is not None
-        ):
-            preferences[
-                'assets_min_qod'
-            ] = input_preferences.create_assets_min_qod
+            if input_preferences.auto_delete_reports is not None:
+                preferences['auto_delete'] = "keep"
+                preferences[
+                    'auto_delete_data'
+                ] = input_preferences.auto_delete_reports
+            else:
+                preferences['auto_delete'] = "no"
 
-        if (
-            input_preferences
-            and input_preferences.auto_delete_reports is not None
-        ):
-            preferences['auto_delete'] = "keep"
-            preferences[
-                'auto_delete_data'
-            ] = input_preferences.auto_delete_reports
+            if input_preferences.create_assets is not None:
+                preferences['in_assets'] = to_yes_no(
+                    input_preferences.create_assets
+                )
 
-        if input_preferences and input_preferences.create_assets is not None:
-            preferences['in_assets'] = to_yes_no(
-                input_preferences.create_assets
-            )
+            if input_preferences.max_concurrent_nvts is not None:
+                preferences[
+                    'max_checks'
+                ] = input_preferences.max_concurrent_nvts
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_nvts is not None
-        ):
-            preferences['max_checks'] = input_preferences.max_concurrent_nvts
-
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_hosts is not None
-        ):
-            preferences['max_hosts'] = input_preferences.max_concurrent_hosts
+            if input_preferences.max_concurrent_hosts is not None:
+                preferences[
+                    'max_hosts'
+                ] = input_preferences.max_concurrent_hosts
 
         gmp = get_gmp(info)
 

--- a/selene/schema/tasks/mutations.py
+++ b/selene/schema/tasks/mutations.py
@@ -229,47 +229,39 @@ class CreateTask(graphene.Mutation):
 
         input_preferences = input_object.preferences
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_apply_overrides is not None
-        ):
-            preferences['assets_apply_overrides'] = to_yes_no(
-                input_preferences.create_assets_apply_overrides
-            )
+        if input_preferences:
+            if input_preferences.create_assets_apply_overrides is not None:
+                preferences['assets_apply_overrides'] = to_yes_no(
+                    input_preferences.create_assets_apply_overrides
+                )
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_min_qod is not None
-        ):
-            preferences[
-                'assets_min_qod'
-            ] = input_preferences.create_assets_min_qod
+            if input_preferences.create_assets_min_qod is not None:
+                preferences[
+                    'assets_min_qod'
+                ] = input_preferences.create_assets_min_qod
 
-        if (
-            input_preferences
-            and input_preferences.auto_delete_reports is not None
-        ):
-            preferences['auto_delete'] = "keep"
-            preferences[
-                'auto_delete_data'
-            ] = input_preferences.auto_delete_reports
+            if input_preferences.auto_delete_reports is not None:
+                preferences['auto_delete'] = "keep"
+                preferences[
+                    'auto_delete_data'
+                ] = input_preferences.auto_delete_reports
+            else:
+                preferences['auto_delete'] = "no"
 
-        if input_preferences and input_preferences.create_assets is not None:
-            preferences['in_assets'] = to_yes_no(
-                input_preferences.create_assets
-            )
+            if input_preferences.create_assets is not None:
+                preferences['in_assets'] = to_yes_no(
+                    input_preferences.create_assets
+                )
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_nvts is not None
-        ):
-            preferences['max_checks'] = input_preferences.max_concurrent_nvts
+            if input_preferences.max_concurrent_nvts is not None:
+                preferences[
+                    'max_checks'
+                ] = input_preferences.max_concurrent_nvts
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_hosts is not None
-        ):
-            preferences['max_hosts'] = input_preferences.max_concurrent_hosts
+            if input_preferences.max_concurrent_hosts is not None:
+                preferences[
+                    'max_hosts'
+                ] = input_preferences.max_concurrent_hosts
 
         gmp = get_gmp(info)
 
@@ -391,47 +383,39 @@ class ModifyTask(graphene.Mutation):
 
         input_preferences = input_object.preferences
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_apply_overrides is not None
-        ):
-            preferences['assets_apply_overrides'] = to_yes_no(
-                input_preferences.create_assets_apply_overrides
-            )
+        if input_preferences:
+            if input_preferences.create_assets_apply_overrides is not None:
+                preferences['assets_apply_overrides'] = to_yes_no(
+                    input_preferences.create_assets_apply_overrides
+                )
 
-        if (
-            input_preferences
-            and input_preferences.create_assets_min_qod is not None
-        ):
-            preferences[
-                'assets_min_qod'
-            ] = input_preferences.create_assets_min_qod
+            if input_preferences.create_assets_min_qod is not None:
+                preferences[
+                    'assets_min_qod'
+                ] = input_preferences.create_assets_min_qod
 
-        if (
-            input_preferences
-            and input_preferences.auto_delete_reports is not None
-        ):
-            preferences['auto_delete'] = "keep"
-            preferences[
-                'auto_delete_data'
-            ] = input_preferences.auto_delete_reports
+            if input_preferences.auto_delete_reports is not None:
+                preferences['auto_delete'] = "keep"
+                preferences[
+                    'auto_delete_data'
+                ] = input_preferences.auto_delete_reports
+            else:
+                preferences['auto_delete'] = "no"
 
-        if input_preferences and input_preferences.create_assets is not None:
-            preferences['in_assets'] = to_yes_no(
-                input_preferences.create_assets
-            )
+            if input_preferences.create_assets is not None:
+                preferences['in_assets'] = to_yes_no(
+                    input_preferences.create_assets
+                )
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_nvts is not None
-        ):
-            preferences['max_checks'] = input_preferences.max_concurrent_nvts
+            if input_preferences.max_concurrent_nvts is not None:
+                preferences[
+                    'max_checks'
+                ] = input_preferences.max_concurrent_nvts
 
-        if (
-            input_preferences
-            and input_preferences.max_concurrent_hosts is not None
-        ):
-            preferences['max_hosts'] = input_preferences.max_concurrent_hosts
+            if input_preferences.max_concurrent_hosts is not None:
+                preferences[
+                    'max_hosts'
+                ] = input_preferences.max_concurrent_hosts
 
         gmp = get_gmp(info)
 

--- a/selene/tests/audits/test_create_audit.py
+++ b/selene/tests/audits/test_create_audit.py
@@ -110,3 +110,69 @@ class CreateAuditTestCase(SeleneTestCase):
             schedule_id=None,
             schedule_periods=None,
         )
+
+    def test_create_audit_auto_delete_reports_none(
+        self, mock_gmp: GmpMockFactory
+    ):
+        audit_id = str(uuid4())
+        policy_id = str(uuid4())
+        target_id = str(uuid4())
+        scanner_id = str(uuid4())
+
+        mock_gmp.mock_response(
+            'create_audit',
+            f'''
+            <create_task_response id="{audit_id}" status="200" status_text="OK"/>
+            ''',
+        )
+
+        self.login('foo', 'bar')
+
+        response = self.query(
+            f'''
+            mutation {{
+                createAudit(input: {{
+                    name: "bar",
+                    scannerId: "{scanner_id}",
+                    policyId: "{policy_id}",
+                    targetId: "{target_id}",
+                    preferences: {{
+                        createAssets: true,
+                        createAssetsApplyOverrides: false,
+                        maxConcurrentNvts: 7,
+                        maxConcurrentHosts: 13,
+                    }}
+                }}) {{
+                    id
+                }}
+            }}
+            '''
+        )
+
+        json = response.json()
+
+        self.assertResponseNoErrors(response)
+
+        uuid = json['data']['createAudit']['id']
+
+        self.assertEqual(uuid, audit_id)
+
+        mock_gmp.gmp_protocol.create_audit.assert_called_with(
+            "bar",
+            policy_id,
+            target_id,
+            scanner_id,
+            alert_ids=None,
+            alterable=None,
+            comment=None,
+            observers=None,
+            preferences={
+                'auto_delete': 'no',
+                'max_checks': 7,
+                'max_hosts': 13,
+                'in_assets': 'yes',
+                'assets_apply_overrides': 'no',
+            },
+            schedule_id=None,
+            schedule_periods=None,
+        )


### PR DESCRIPTION
**What**:

Extend create and modify of task and audit to allow to deactivate the
auto deletion of reports. if the autoDeleteReports preference is not set
or is null no reports will be deleted automatically anymore.

**Why**:

it must be possible to deactivate the auto deletion of reports

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
