### PR TITLE
Audit/task cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ $ cd hyperion && git log
 
 ### Changed
 
-- Revisit audit and task object types [#133](https://github.com/greenbone/hyperion/pull/133), [#149](https://github.com/greenbone/hyperion/pull/149)
+- Revisit audit and task object types [#133](https://github.com/greenbone/hyperion/pull/133), [#149](https://github.com/greenbone/hyperion/pull/149), [#150](https://github.com/greenbone/hyperion/pull/150)
 - Revisit authentication methods [#93](https://github.com/greenbone/hyperion/pull/93)
 - Revisit port list object type, queries and mutations [#108](https://github.com/greenbone/hyperion/pull/108)
 - Revisit feed status object types [#95](https://github.com/greenbone/hyperion/pull/95), [#122](https://github.com/greenbone/hyperion/pull/122)

--- a/selene/schema/audits/fields.py
+++ b/selene/schema/audits/fields.py
@@ -388,9 +388,6 @@ class Audit(EntityObjectType):
     schedule = graphene.Field(
         AuditSchedule, description="Used schedule for the audit"
     )
-    schedule_periods = graphene.Int(
-        description="Number of recurrences for the schedule"
-    )
 
     preferences = graphene.Field(
         AuditPreferences, description="Preferences set for the audit"
@@ -450,10 +447,6 @@ class Audit(EntityObjectType):
     @staticmethod
     def resolve_schedule(root, _info):
         return get_sub_element_if_id_available(root, 'schedule')
-
-    @staticmethod
-    def resolve_schedule_periods(root, _info):
-        return get_int_from_element(root, 'schedule_periods')
 
     @staticmethod
     def resolve_preferences(root, _info):

--- a/selene/schema/audits/mutations.py
+++ b/selene/schema/audits/mutations.py
@@ -136,12 +136,6 @@ class CreateAuditInput(graphene.InputObjectType):
     schedule_id = graphene.UUID(
         description="UUID of a schedule when the audit should be run"
     )
-    schedule_periods = graphene.Int(
-        description=(
-            "A limit to the number of times the "
-            "audit will be scheduled, or 0 for no limit"
-        )
-    )
 
 
 class CreateAudit(graphene.Mutation):
@@ -162,7 +156,6 @@ class CreateAudit(graphene.Mutation):
 
         name = input_object.name
         alterable = input_object.alterable
-        schedule_periods = input_object.schedule_periods
         comment = input_object.comment
 
         if input_object.alert_ids is not None:
@@ -239,7 +232,6 @@ class CreateAudit(graphene.Mutation):
             comment=comment,
             alert_ids=alert_ids,
             schedule_id=schedule_id,
-            schedule_periods=schedule_periods,
             preferences=preferences,
         )
         return CreateAudit(audit_id=resp.get('id'))
@@ -270,12 +262,6 @@ class ModifyAuditInput(graphene.InputObjectType):
     schedule_id = graphene.UUID(
         description="UUID of a schedule when the audit should be run."
     )
-    schedule_periods = graphene.Int(
-        description=(
-            "A limit to the number of times the "
-            "audit will be scheduled, or 0 for no limit."
-        )
-    )
 
 
 class ModifyAudit(graphene.Mutation):
@@ -299,7 +285,6 @@ class ModifyAudit(graphene.Mutation):
         audit_id = str(input_object.audit_id)
         name = input_object.name
         comment = input_object.comment
-        schedule_periods = input_object.schedule_periods
         alterable = input_object.alterable
 
         if input_object.alert_ids is not None:
@@ -363,7 +348,6 @@ class ModifyAudit(graphene.Mutation):
             scanner_id=scanner_id,
             alterable=alterable,
             schedule_id=schedule_id,
-            schedule_periods=schedule_periods,
             comment=comment,
             alert_ids=alert_ids,
             preferences=preferences,

--- a/selene/schema/audits/mutations.py
+++ b/selene/schema/audits/mutations.py
@@ -26,6 +26,7 @@ from selene.schema.entities import (
 )
 
 from selene.schema.utils import (
+    RESET_UUID,
     get_gmp,
     require_authentication,
     get_text_from_element,
@@ -258,14 +259,15 @@ class ModifyAuditInput(graphene.InputObjectType):
     """Input ObjectType for modifying an audit"""
 
     audit_id = graphene.UUID(
-        required=True, description="UUID of the audit to modify.", name='id'
+        description="UUID of the audit to modify.", name='id', required=True
     )
-    name = graphene.String(description="Audit name")
+    name = graphene.String(description="Audit name", required=True)
+    target_id = graphene.UUID(description="UUID of target", required=True)
     policy_id = graphene.UUID(
-        description=("UUID of policy. OpenVAS Default scanners only")
+        description=("UUID of policy. OpenVAS Default scanners only"),
+        required=True,
     )
-    target_id = graphene.UUID(description="UUID of target")
-    scanner_id = graphene.UUID(description="UUID of scanner")
+    scanner_id = graphene.UUID(description="UUID of scanner", required=True)
 
     alert_ids = graphene.List(
         graphene.UUID, description="List of UUIDs for alerts"
@@ -314,32 +316,21 @@ class ModifyAudit(graphene.Mutation):
         if input_object.alert_ids is not None:
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
-            alert_ids = None
+            alert_ids = []
 
         if input_object.observers is not None:
             observers = [str(observer) for observer in input_object.observers]
         else:
             observers = None
 
+        target_id = str(input_object.target_id)
+        scanner_id = str(input_object.scanner_id)
+        policy_id = str(input_object.policy_id)
+
         schedule_id = (
             str(input_object.schedule_id)
             if input_object.schedule_id is not None
-            else None
-        )
-        scanner_id = (
-            str(input_object.scanner_id)
-            if input_object.scanner_id is not None
-            else None
-        )
-        target_id = (
-            str(input_object.target_id)
-            if input_object.target_id is not None
-            else None
-        )
-        policy_id = (
-            str(input_object.policy_id)
-            if input_object.policy_id is not None
-            else None
+            else RESET_UUID
         )
 
         preferences = {}

--- a/selene/schema/audits/mutations.py
+++ b/selene/schema/audits/mutations.py
@@ -130,11 +130,6 @@ class CreateAuditInput(graphene.InputObjectType):
         description="Whether the audit should be alterable"
     )
     comment = graphene.String(description="Audit comment")
-    observers = graphene.List(
-        graphene.UUID,
-        description="List of UUIDs for users which should be allowed to "
-        "observe the audit",
-    )
     preferences = graphene.Field(
         AuditPreferencesInput, description="Preferences to set for the audit"
     )
@@ -174,10 +169,6 @@ class CreateAudit(graphene.Mutation):
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
             alert_ids = None
-        if input_object.observers is not None:
-            observers = [str(observer) for observer in input_object.observers]
-        else:
-            observers = None
 
         schedule_id = (
             str(input_object.schedule_id)
@@ -249,7 +240,6 @@ class CreateAudit(graphene.Mutation):
             alert_ids=alert_ids,
             schedule_id=schedule_id,
             schedule_periods=schedule_periods,
-            observers=observers,
             preferences=preferences,
         )
         return CreateAudit(audit_id=resp.get('id'))
@@ -274,7 +264,6 @@ class ModifyAuditInput(graphene.InputObjectType):
     )
     alterable = graphene.Boolean(description="Whether the audit is alterable")
     comment = graphene.String(description="Audit comment")
-    observers = graphene.List(graphene.String)
     preferences = graphene.Field(
         AuditPreferencesInput, description="Preferences to set for the audit"
     )
@@ -317,11 +306,6 @@ class ModifyAudit(graphene.Mutation):
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
             alert_ids = []
-
-        if input_object.observers is not None:
-            observers = [str(observer) for observer in input_object.observers]
-        else:
-            observers = None
 
         target_id = str(input_object.target_id)
         scanner_id = str(input_object.scanner_id)
@@ -382,7 +366,6 @@ class ModifyAudit(graphene.Mutation):
             schedule_periods=schedule_periods,
             comment=comment,
             alert_ids=alert_ids,
-            observers=observers,
             preferences=preferences,
         )
 

--- a/selene/schema/tasks/fields.py
+++ b/selene/schema/tasks/fields.py
@@ -384,9 +384,6 @@ class Task(EntityObjectType):
     schedule = graphene.Field(
         TaskSchedule, description="Used schedule for the task"
     )
-    schedule_periods = graphene.Int(
-        description="Number of recurrences for the schedule"
-    )
 
     preferences = graphene.Field(
         TaskPreferences, description="Preferences set for the task"
@@ -440,10 +437,6 @@ class Task(EntityObjectType):
     @staticmethod
     def resolve_schedule(root, _info):
         return get_sub_element_if_id_available(root, 'schedule')
-
-    @staticmethod
-    def resolve_schedule_periods(root, _info):
-        return get_int_from_element(root, 'schedule_periods')
 
     @staticmethod
     def resolve_preferences(root, _info):

--- a/selene/schema/tasks/mutations.py
+++ b/selene/schema/tasks/mutations.py
@@ -26,6 +26,7 @@ from selene.schema.entities import (
 )
 
 from selene.schema.utils import (
+    RESET_UUID,
     get_gmp,
     require_authentication,
     get_text_from_element,
@@ -153,7 +154,7 @@ class CreateTaskInput(graphene.InputObjectType):
         description="List of UUIDs for alerts to be used for the task",
     )
     alterable = graphene.Boolean(
-        description="Whether the task should be alterable"
+        description="Whether the task should be alterable",
     )
     comment = graphene.String(description="Task comment")
     observers = graphene.List(
@@ -171,7 +172,7 @@ class CreateTaskInput(graphene.InputObjectType):
         description=(
             "A limit to the number of times the "
             "task will be scheduled, or 0 for no limit"
-        )
+        ),
     )
 
 
@@ -200,10 +201,12 @@ class CreateTask(graphene.Mutation):
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
             alert_ids = None
+
         if input_object.observers is not None:
             observers = [str(observer) for observer in input_object.observers]
         else:
             observers = None
+
         schedule_id = (
             str(input_object.schedule_id)
             if input_object.schedule_id is not None
@@ -285,24 +288,30 @@ class ModifyTaskInput(graphene.InputObjectType):
     """Input ObjectType for modifying a task"""
 
     task_id = graphene.UUID(
-        required=True, description="UUID of task to modify.", name='id'
+        description="UUID of task to modify", name='id', required=True
     )
-    name = graphene.String(description="Task name")
+    name = graphene.String(description="Task name", required=True)
+    target_id = graphene.UUID(
+        description="UUID of the target to be used", required=True
+    )
+    scanner_id = graphene.UUID(
+        description="UUID of the scanner to be used", required=True
+    )
+
     scan_config_id = graphene.UUID(
         description=(
             "UUID of the scan config to use for the scanner. "
             "Only for OpenVAS scanners"
         ),
+        required=True,
     )
-    target_id = graphene.UUID(description="UUID of the target to be used")
-    scanner_id = graphene.UUID(description="UUID of the scanner to be used")
 
     alert_ids = graphene.List(
         graphene.UUID,
         description="List of UUIDs for alerts to be used for the task",
     )
     alterable = graphene.Boolean(
-        description="Whether the task should be alterable"
+        description="Whether the task should be alterable",
     )
     comment = graphene.String(description="Task comment")
     observers = graphene.List(
@@ -320,7 +329,7 @@ class ModifyTaskInput(graphene.InputObjectType):
         description=(
             "A limit to the number of times the "
             "task will be scheduled, or 0 for no limit."
-        )
+        ),
     )
 
 
@@ -351,32 +360,21 @@ class ModifyTask(graphene.Mutation):
         if input_object.alert_ids is not None:
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
-            alert_ids = None
+            alert_ids = []
 
         if input_object.observers is not None:
             observers = [str(observer) for observer in input_object.observers]
         else:
             observers = None
 
+        target_id = str(input_object.target_id)
+        scanner_id = str(input_object.scanner_id)
+        config_id = str(input_object.scan_config_id)
+
         schedule_id = (
             str(input_object.schedule_id)
             if input_object.schedule_id is not None
-            else None
-        )
-        scanner_id = (
-            str(input_object.scanner_id)
-            if input_object.scanner_id is not None
-            else None
-        )
-        target_id = (
-            str(input_object.target_id)
-            if input_object.target_id is not None
-            else None
-        )
-        config_id = (
-            str(input_object.scan_config_id)
-            if input_object.scan_config_id is not None
-            else None
+            else RESET_UUID
         )
 
         preferences = {}

--- a/selene/schema/tasks/mutations.py
+++ b/selene/schema/tasks/mutations.py
@@ -163,12 +163,6 @@ class CreateTaskInput(graphene.InputObjectType):
     schedule_id = graphene.UUID(
         description="UUID of a schedule when the task should be run"
     )
-    schedule_periods = graphene.Int(
-        description=(
-            "A limit to the number of times the "
-            "task will be scheduled, or 0 for no limit"
-        ),
-    )
 
 
 class CreateTask(graphene.Mutation):
@@ -189,7 +183,6 @@ class CreateTask(graphene.Mutation):
 
         name = input_object.name
         alterable = input_object.alterable
-        schedule_periods = input_object.schedule_periods
         comment = input_object.comment
 
         if input_object.alert_ids is not None:
@@ -267,7 +260,6 @@ class CreateTask(graphene.Mutation):
             comment=comment,
             alert_ids=alert_ids,
             schedule_id=schedule_id,
-            schedule_periods=schedule_periods,
             preferences=preferences,
         )
         return CreateTask(task_id=resp.get('id'))
@@ -309,12 +301,6 @@ class ModifyTaskInput(graphene.InputObjectType):
     schedule_id = graphene.UUID(
         description="UUID of a schedule when the task should be run"
     )
-    schedule_periods = graphene.Int(
-        description=(
-            "A limit to the number of times the "
-            "task will be scheduled, or 0 for no limit."
-        ),
-    )
 
 
 class ModifyTask(graphene.Mutation):
@@ -338,7 +324,6 @@ class ModifyTask(graphene.Mutation):
         task_id = str(input_object.task_id)
         name = input_object.name
         comment = input_object.comment
-        schedule_periods = input_object.schedule_periods
         alterable = input_object.alterable
 
         if input_object.alert_ids is not None:
@@ -404,7 +389,6 @@ class ModifyTask(graphene.Mutation):
             scanner_id=scanner_id,
             alterable=alterable,
             schedule_id=schedule_id,
-            schedule_periods=schedule_periods,
             comment=comment,
             alert_ids=alert_ids,
             preferences=preferences,

--- a/selene/schema/tasks/mutations.py
+++ b/selene/schema/tasks/mutations.py
@@ -157,11 +157,6 @@ class CreateTaskInput(graphene.InputObjectType):
         description="Whether the task should be alterable",
     )
     comment = graphene.String(description="Task comment")
-    observers = graphene.List(
-        graphene.String,
-        description="List of UUIDs for users which should be allowed to "
-        "observe the task",
-    )
     preferences = graphene.Field(
         TaskPreferencesInput, description="Preferences to set for the task"
     )
@@ -201,11 +196,6 @@ class CreateTask(graphene.Mutation):
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
             alert_ids = None
-
-        if input_object.observers is not None:
-            observers = [str(observer) for observer in input_object.observers]
-        else:
-            observers = None
 
         schedule_id = (
             str(input_object.schedule_id)
@@ -278,7 +268,6 @@ class CreateTask(graphene.Mutation):
             alert_ids=alert_ids,
             schedule_id=schedule_id,
             schedule_periods=schedule_periods,
-            observers=observers,
             preferences=preferences,
         )
         return CreateTask(task_id=resp.get('id'))
@@ -314,11 +303,6 @@ class ModifyTaskInput(graphene.InputObjectType):
         description="Whether the task should be alterable",
     )
     comment = graphene.String(description="Task comment")
-    observers = graphene.List(
-        graphene.String,
-        description="List of UUIDs for users which should be allowed to "
-        "observe the task",
-    )
     preferences = graphene.Field(
         TaskPreferencesInput, description="Preferences to set for the task"
     )
@@ -361,11 +345,6 @@ class ModifyTask(graphene.Mutation):
             alert_ids = [str(alert_id) for alert_id in input_object.alert_ids]
         else:
             alert_ids = []
-
-        if input_object.observers is not None:
-            observers = [str(observer) for observer in input_object.observers]
-        else:
-            observers = None
 
         target_id = str(input_object.target_id)
         scanner_id = str(input_object.scanner_id)
@@ -428,7 +407,6 @@ class ModifyTask(graphene.Mutation):
             schedule_periods=schedule_periods,
             comment=comment,
             alert_ids=alert_ids,
-            observers=observers,
             preferences=preferences,
         )
 

--- a/selene/schema/utils.py
+++ b/selene/schema/utils.py
@@ -32,6 +32,8 @@ from selene.schema.parser import parse_bool, parse_datetime, parse_int
 
 XmlElement = ElementTree.Element  # pylint: disable=invalid-name
 
+RESET_UUID = "0"
+
 
 def has_id(element: XmlElement) -> bool:
     if element is None:

--- a/selene/tests/audits/test_create_audit.py
+++ b/selene/tests/audits/test_create_audit.py
@@ -107,7 +107,6 @@ class CreateAuditTestCase(SeleneTestCase):
                 'assets_apply_overrides': 'no',
             },
             schedule_id=None,
-            schedule_periods=None,
         )
 
     def test_create_audit_auto_delete_reports_none(
@@ -172,5 +171,4 @@ class CreateAuditTestCase(SeleneTestCase):
                 'assets_apply_overrides': 'no',
             },
             schedule_id=None,
-            schedule_periods=None,
         )

--- a/selene/tests/audits/test_create_audit.py
+++ b/selene/tests/audits/test_create_audit.py
@@ -98,7 +98,6 @@ class CreateAuditTestCase(SeleneTestCase):
             alert_ids=None,
             alterable=None,
             comment=None,
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -165,7 +164,6 @@ class CreateAuditTestCase(SeleneTestCase):
             alert_ids=None,
             alterable=None,
             comment=None,
-            observers=None,
             preferences={
                 'auto_delete': 'no',
                 'max_checks': 7,

--- a/selene/tests/audits/test_modify_audit.py
+++ b/selene/tests/audits/test_modify_audit.py
@@ -115,7 +115,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             comment="Foo Bar",
             policy_id=policy_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -190,7 +189,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             comment="Foo Bar",
             policy_id=policy_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'no',
                 'max_checks': 7,
@@ -261,7 +259,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             comment="Foo Bar",
             policy_id=policy_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -333,7 +330,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             comment="Foo Bar",
             policy_id=policy_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,

--- a/selene/tests/audits/test_modify_audit.py
+++ b/selene/tests/audits/test_modify_audit.py
@@ -125,7 +125,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -198,7 +197,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -269,7 +267,6 @@ class ModifyAuditTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=RESET_UUID,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -340,6 +337,5 @@ class ModifyAuditTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )

--- a/selene/tests/tasks/test_create_task.py
+++ b/selene/tests/tasks/test_create_task.py
@@ -105,7 +105,6 @@ class CreateTaskTestCase(SeleneTestCase):
                 'assets_apply_overrides': 'no',
             },
             schedule_id=None,
-            schedule_periods=None,
         )
 
     def test_create_task_auto_delete_reports_none(
@@ -170,5 +169,4 @@ class CreateTaskTestCase(SeleneTestCase):
                 'assets_apply_overrides': 'no',
             },
             schedule_id=None,
-            schedule_periods=None,
         )

--- a/selene/tests/tasks/test_create_task.py
+++ b/selene/tests/tasks/test_create_task.py
@@ -96,7 +96,6 @@ class CreateTaskTestCase(SeleneTestCase):
             alert_ids=None,
             alterable=None,
             comment=None,
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -163,7 +162,6 @@ class CreateTaskTestCase(SeleneTestCase):
             alert_ids=None,
             alterable=None,
             comment=None,
-            observers=None,
             preferences={
                 'auto_delete': 'no',
                 'max_checks': 7,

--- a/selene/tests/tasks/test_get_task.py
+++ b/selene/tests/tasks/test_get_task.py
@@ -298,7 +298,6 @@ class TaskTestCase(SeleneTestCase):
                         id
                         name
                     }
-                    schedulePeriods
                 }
             }
             '''
@@ -342,10 +341,6 @@ class TaskTestCase(SeleneTestCase):
         self.assertEqual(schedule['timezone'], 'UTC')
         self.assertRegex(schedule['icalendar'], r'^BEGIN:VCALENDAR.*')
         self.assertEqual(schedule['timezone'], 'UTC')
-
-        schedule_periods = task['schedulePeriods']
-
-        self.assertEqual(schedule_periods, 0)
 
         alerts = task['alerts']
         self.assertEqual(len(alerts), 2)

--- a/selene/tests/tasks/test_modify_task.py
+++ b/selene/tests/tasks/test_modify_task.py
@@ -115,7 +115,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             comment="Foo Bar",
             config_id=scan_config_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -190,7 +189,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             comment="Foo Bar",
             config_id=scan_config_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'no',
                 'max_checks': 7,
@@ -261,7 +259,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             comment="Foo Bar",
             config_id=scan_config_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,
@@ -333,7 +330,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             comment="Foo Bar",
             config_id=scan_config_id,
             name="bar",
-            observers=None,
             preferences={
                 'auto_delete': 'keep',
                 'auto_delete_data': 4,

--- a/selene/tests/tasks/test_modify_task.py
+++ b/selene/tests/tasks/test_modify_task.py
@@ -125,7 +125,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -198,7 +197,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -269,7 +267,6 @@ class ModifyTaskTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=RESET_UUID,
-            schedule_periods=None,
             target_id=target_id,
         )
 
@@ -340,6 +337,5 @@ class ModifyTaskTestCase(SeleneTestCase):
             },
             scanner_id=scanner_id,
             schedule_id=schedule_id,
-            schedule_periods=None,
             target_id=target_id,
         )


### PR DESCRIPTION
**What**:

* Allow to reset schedules of audits and tasks in modify mutations
* Allow to reset alerts of audits and tasks in modify mutations
* Require target_id, scanner_id, name and scan_config_id for modify task
* Require target_id, scanner_id, name and policy_id for modify audit
* Remove observers from create and modify task and audit mutations

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/hyperion/blob/master/CHANGELOG.md) Entry
- [x] Documentation
